### PR TITLE
fix: node imports

### DIFF
--- a/apps/docs/.vitepress/utils.ts
+++ b/apps/docs/.vitepress/utils.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import fs from 'fs'
+import path from 'path'
 
 export const scanDir = (dir: string) => {
   let res = fs.readdirSync(path.resolve(__dirname, `../${dir}`)).filter(item => !item.startsWith('.')) as string[]

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,4 +1,4 @@
-const { resolve } = require("node:path");
+const { resolve } = require("path");
 
 const project = resolve(process.cwd(), "tsconfig.json");
 

--- a/packages/safe-fs/src/__tests__/fs.test.ts
+++ b/packages/safe-fs/src/__tests__/fs.test.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import fs from 'fs'
+import path from 'path'
 
 import { vol } from 'memfs'
 import { beforeEach, describe, expect, it } from 'vitest'

--- a/packages/safe-fs/src/__tests__/fs.test.ts
+++ b/packages/safe-fs/src/__tests__/fs.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
-import path from 'path'
-
 import { vol } from 'memfs'
+import path from 'path'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { createGetter } from '@/getter'

--- a/packages/safe-fs/src/getter.ts
+++ b/packages/safe-fs/src/getter.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import fs from 'fs'
 
 import PARAMS_TO_SANITIZE from '@/params'
 import { sanitizePath } from '@/sanitizers'

--- a/packages/safe-fs/src/index.ts
+++ b/packages/safe-fs/src/index.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import * as fs from 'node:fs'
+import * as fs from 'fs'
 
 import { createGetter } from '@/getter'
 

--- a/packages/safe-fs/src/sanitizers.ts
+++ b/packages/safe-fs/src/sanitizers.ts
@@ -1,5 +1,5 @@
-import { PathLike } from 'node:fs'
-import path from 'node:path'
+import { PathLike } from 'fs'
+import path from 'path'
 
 const LEADING_DOT_SLASH_REGEX = /^(\.\.(\/|\\|$))+/
 

--- a/packages/safe-fs/vitest.config.ts
+++ b/packages/safe-fs/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 export default {
   resolve: {

--- a/packages/safe-fs/vitest.setup.ts
+++ b/packages/safe-fs/vitest.setup.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest'
 
-vi.mock('node:fs', async () => {
+vi.mock('fs', async () => {
   const memfs: { fs: typeof fs } = await vi.importActual('memfs')
 
   return {
@@ -10,7 +10,7 @@ vi.mock('node:fs', async () => {
   }
 })
 
-vi.mock('node:fs/promises', async () => {
+vi.mock('fs/promises', async () => {
   const memfs: { fs: typeof fs } = await vi.importActual('memfs')
 
   return {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -4,6 +4,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./url": {
       "types": "./dist/url/index.d.ts",
       "default": "./dist/url/index.js"
@@ -19,6 +23,9 @@
   },
   "typesVersions": {
     "*": {
+      ".": [
+        "./dist/index.d.ts"
+      ],
       "url": [
         "./dist/url/index.d.ts"
       ],

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/src/__tests__/path.test.ts
+++ b/packages/validators/src/__tests__/path.test.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { describe, expect, it } from 'vitest'
 import { ZodError } from 'zod'
 

--- a/packages/validators/src/__tests__/path.test.ts
+++ b/packages/validators/src/__tests__/path.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 import { describe, expect, it } from 'vitest'
 import { ZodError } from 'zod'

--- a/packages/validators/src/path/options.ts
+++ b/packages/validators/src/path/options.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { z } from 'zod'
 
 /**

--- a/packages/validators/src/path/options.ts
+++ b/packages/validators/src/path/options.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 import { z } from 'zod'
 

--- a/packages/validators/src/path/schema.ts
+++ b/packages/validators/src/path/schema.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { z } from 'zod'
 
 import { ParsedPathValidatorOptions } from '@/path/options'

--- a/packages/validators/src/path/schema.ts
+++ b/packages/validators/src/path/schema.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 import { z } from 'zod'
 

--- a/packages/validators/src/path/utils.ts
+++ b/packages/validators/src/path/utils.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 export const isSafePath = (absPath: string, basePath: string): boolean => {
   // check for poison null bytes

--- a/packages/validators/vitest.config.ts
+++ b/packages/validators/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 export default {
   resolve: {


### PR DESCRIPTION
This PR addresses an issue with the path validator introduced in versions 1.2.3 to 1.2.7 of our package. The `node:path` import syntax, while explicitly pointing to a Node.js built-in module, is not supported by the Next.js webpack configuration, causing build failures in some projects.

**Changes:**
- Removed `node:` prefix from `fs` and `path` import statements

**Rationale:**
1. This change resolves build failures in Next.js projects
2. Security concerns about package squatting are mitigated:
   - Node.js [preferentially loads](https://nodejs.org/api/modules.html#built-in-modules) built-in modules like `fs` and `path` even without the `node:` prefix. 
   - [Node.js module resolution algorithm](https://nodejs.org/api/modules.html#loading-from-node_modules-folders) prioritises built-in modules over similarly named packages in `node_modules`
   - The `fs` and `path` package names on npm are currently benign.

**Impact:**
- Fixes breaking builds with Next.js
- No security issues introduced by changing the import specifier
