### PR TITLE
feat: simplify redirect url pattern

### DIFF
--- a/apps/docs/.vitepress/utils.ts
+++ b/apps/docs/.vitepress/utils.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import fs from 'fs'
+import path from 'path'
 
 export const scanDir = (dir: string) => {
   let res = fs.readdirSync(path.resolve(__dirname, `../${dir}`)).filter(item => !item.startsWith('.')) as string[]

--- a/apps/docs/examples/validators.md
+++ b/apps/docs/examples/validators.md
@@ -52,20 +52,32 @@ Validating a post-login redirect URL provided in a query parameter:
 ```javascript
 import { UrlValidator } from '@opengovsg/starter-kitty-validators/url'
 
+const validator = new RelUrlValidator(window.location.origin)
+```
+
+```javascript
+const fallbackUrl = '/home'
+window.location.pathname = validator.parsePathname(redirectUrl, fallbackUrl)
+
+// alternatively
+router.push(validator.parsePathname(redirectUrl, fallbackUrl))
+```
+
+For more control you can create the UrlValidator instance yourself and invoke .parse
+
+```javascript
+import { UrlValidator } from '@opengovsg/starter-kitty-validators/url'
+
 const validator = new UrlValidator({
   whitelist: {
     protocols: ['http', 'https', 'mailto'],
     hosts: ['open.gov.sg'],
   },
 })
-```
 
-```javascript
-try {
-  router.push(validator.parse(redirectUrl))
-} catch (error) {
-  router.push('/home')
-}
+...
+
+validator.parse(userInput)
 ```
 
 Using the validator as part of a Zod schema to validate the URL and fall back to a default URL if the URL is invalid:

--- a/etc/starter-kitty-validators.api.md
+++ b/etc/starter-kitty-validators.api.md
@@ -38,6 +38,11 @@ export interface PathValidatorOptions {
 }
 
 // @public
+export class RelUrlValidator extends UrlValidator {
+    constructor(origin: string | URL);
+}
+
+// @public
 export class UrlValidationError extends Error {
     constructor(message: string);
 }
@@ -45,7 +50,16 @@ export class UrlValidationError extends Error {
 // @public
 export class UrlValidator {
     constructor(options?: UrlValidatorOptions);
+    parse<T extends string | URL>(url: string, fallbackUrl: T): URL | T;
+    // (undocumented)
     parse(url: string): URL;
+    // (undocumented)
+    parse(url: string, fallbackUrl: undefined): URL;
+    parsePathname<T extends string | URL>(url: string, fallbackUrl: T): string;
+    // (undocumented)
+    parsePathname(url: string): string;
+    // (undocumented)
+    parsePathname(url: string, fallbackUrl: undefined): string;
 }
 
 // @public

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,4 +1,4 @@
-const { resolve } = require("node:path");
+const { resolve } = require("path");
 
 const project = resolve(process.cwd(), "tsconfig.json");
 

--- a/packages/safe-fs/src/__tests__/fs.test.ts
+++ b/packages/safe-fs/src/__tests__/fs.test.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import fs from 'fs'
+import path from 'path'
 
 import { vol } from 'memfs'
 import { beforeEach, describe, expect, it } from 'vitest'

--- a/packages/safe-fs/src/__tests__/fs.test.ts
+++ b/packages/safe-fs/src/__tests__/fs.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
-import path from 'path'
-
 import { vol } from 'memfs'
+import path from 'path'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { createGetter } from '@/getter'

--- a/packages/safe-fs/src/getter.ts
+++ b/packages/safe-fs/src/getter.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import fs from 'fs'
 
 import PARAMS_TO_SANITIZE from '@/params'
 import { sanitizePath } from '@/sanitizers'

--- a/packages/safe-fs/src/index.ts
+++ b/packages/safe-fs/src/index.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import * as fs from 'node:fs'
+import * as fs from 'fs'
 
 import { createGetter } from '@/getter'
 

--- a/packages/safe-fs/src/sanitizers.ts
+++ b/packages/safe-fs/src/sanitizers.ts
@@ -1,5 +1,5 @@
-import { PathLike } from 'node:fs'
-import path from 'node:path'
+import { PathLike } from 'fs'
+import path from 'path'
 
 const LEADING_DOT_SLASH_REGEX = /^(\.\.(\/|\\|$))+/
 

--- a/packages/safe-fs/vitest.config.ts
+++ b/packages/safe-fs/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 export default {
   resolve: {

--- a/packages/safe-fs/vitest.setup.ts
+++ b/packages/safe-fs/vitest.setup.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest'
 
-vi.mock('node:fs', async () => {
+vi.mock('fs', async () => {
   const memfs: { fs: typeof fs } = await vi.importActual('memfs')
 
   return {
@@ -10,7 +10,7 @@ vi.mock('node:fs', async () => {
   }
 })
 
-vi.mock('node:fs/promises', async () => {
+vi.mock('fs/promises', async () => {
   const memfs: { fs: typeof fs } = await vi.importActual('memfs')
 
   return {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -4,6 +4,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./url": {
       "types": "./dist/url/index.d.ts",
       "default": "./dist/url/index.js"
@@ -19,6 +23,9 @@
   },
   "typesVersions": {
     "*": {
+      ".": [
+        "./dist/index.d.ts"
+      ],
       "url": [
         "./dist/url/index.d.ts"
       ],

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/src/__tests__/path.test.ts
+++ b/packages/validators/src/__tests__/path.test.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { describe, expect, it } from 'vitest'
 import { ZodError } from 'zod'
 

--- a/packages/validators/src/__tests__/path.test.ts
+++ b/packages/validators/src/__tests__/path.test.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 import { describe, expect, it } from 'vitest'
 import { ZodError } from 'zod'

--- a/packages/validators/src/path/options.ts
+++ b/packages/validators/src/path/options.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { z } from 'zod'
 
 /**

--- a/packages/validators/src/path/options.ts
+++ b/packages/validators/src/path/options.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 import { z } from 'zod'
 

--- a/packages/validators/src/path/schema.ts
+++ b/packages/validators/src/path/schema.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-
 import { z } from 'zod'
 
 import { ParsedPathValidatorOptions } from '@/path/options'

--- a/packages/validators/src/path/schema.ts
+++ b/packages/validators/src/path/schema.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 import { z } from 'zod'
 

--- a/packages/validators/src/path/utils.ts
+++ b/packages/validators/src/path/utils.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 export const isSafePath = (absPath: string, basePath: string): boolean => {
   // check for poison null bytes

--- a/packages/validators/vitest.config.ts
+++ b/packages/validators/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path from 'path'
 
 export default {
   resolve: {


### PR DESCRIPTION
## Context

Currently, there's a common pattern across multiple codebases for handling redirect URLs:

```typescript
const validator = new UrlValidator({
  baseOrigin: new URL(baseUrl).origin,
  whitelist: {
    protocols: ['http', 'https'],
    hosts: [new URL(baseUrl).host],
  }
})

export const callbackUrlSchema = z
  .string()
  .optional()
  .default(RECORDINGS)
  .transform((url, ctx) => {
    try {
      return validator.parse(url)
    } catch (error) {
      ctx.addIssue({
        code: z.ZodIssueCode.custom,
        message: (error as Error).message,
      })
      return z.NEVER
    }
  })
  .catch(new URL(RECORDINGS, baseUrl))

...

await router.push(callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]))

...
```

## Changes
This PR introduces three key improvements to our URL validation and redirection process:
1. New `RelUrlValidator` Class
Simplifies the creation of UrlValidator with sensible defaults
Usage: `new RelUrlValidator(origin: string | URL)`
2. Enhanced `UrlValidator.parse(..., fallbackUrl: string | URL)`
Adds a `fallbackUrl` parameter
Eliminates the need to use `callbackUrlSchema`
3. `parsePathname` method
Introduces `UrlValidator.parsePathname(...)` that can be directly assigned to `window.location.pathname`

## Example usage
```typescript
const validator = new RelUrlValidator(baseUrl)
window.location.pathname = validator.parsePathname(router.query['redirect'], '/home'))
```