### PR TITLE
feat: simplify common redirect url pattern

### DIFF
--- a/apps/docs/examples/validators.md
+++ b/apps/docs/examples/validators.md
@@ -52,20 +52,32 @@ Validating a post-login redirect URL provided in a query parameter:
 ```javascript
 import { UrlValidator } from '@opengovsg/starter-kitty-validators/url'
 
+const validator = new RelUrlValidator(window.location.origin)
+```
+
+```javascript
+const fallbackUrl = '/home'
+window.location.pathname = validator.parsePathname(redirectUrl, fallbackUrl)
+
+// alternatively
+router.push(validator.parsePathname(redirectUrl, fallbackUrl))
+```
+
+For more control you can create the UrlValidator instance yourself and invoke .parse
+
+```javascript
+import { UrlValidator } from '@opengovsg/starter-kitty-validators/url'
+
 const validator = new UrlValidator({
   whitelist: {
     protocols: ['http', 'https', 'mailto'],
     hosts: ['open.gov.sg'],
   },
 })
-```
 
-```javascript
-try {
-  router.push(validator.parse(redirectUrl))
-} catch (error) {
-  router.push('/home')
-}
+...
+
+validator.parse(userInput)
 ```
 
 Using the validator as part of a Zod schema to validate the URL and fall back to a default URL if the URL is invalid:

--- a/etc/starter-kitty-validators.api.md
+++ b/etc/starter-kitty-validators.api.md
@@ -38,6 +38,11 @@ export interface PathValidatorOptions {
 }
 
 // @public
+export class RelUrlValidator extends UrlValidator {
+    constructor(origin: string | URL);
+}
+
+// @public
 export class UrlValidationError extends Error {
     constructor(message: string);
 }
@@ -45,7 +50,16 @@ export class UrlValidationError extends Error {
 // @public
 export class UrlValidator {
     constructor(options?: UrlValidatorOptions);
+    parse<T extends string | URL>(url: string, fallbackUrl: T): URL | T;
+    // (undocumented)
     parse(url: string): URL;
+    // (undocumented)
+    parse(url: string, fallbackUrl: undefined): URL;
+    parsePathname<T extends string | URL>(url: string, fallbackUrl: T): string;
+    // (undocumented)
+    parsePathname(url: string): string;
+    // (undocumented)
+    parsePathname(url: string, fallbackUrl: undefined): string;
 }
 
 // @public

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/src/__tests__/url.test.ts
+++ b/packages/validators/src/__tests__/url.test.ts
@@ -249,7 +249,7 @@ describe('UrlValidatorOptions.parsePathname', () => {
 
   it('should fallback to fallbackUrl if it is provided', () => {
     const pathname = validator.parsePathname('https://b.com/hello', 'bye')
-    expect(pathname).toStrictEqual('bye')
+    expect(pathname).toStrictEqual('/bye')
   })
 })
 

--- a/packages/validators/src/url/index.ts
+++ b/packages/validators/src/url/index.ts
@@ -1,4 +1,4 @@
-import { string, ZodError, ZodSchema, ZodTypeDef } from 'zod'
+import { ZodError, ZodSchema, ZodTypeDef } from 'zod'
 import { fromError } from 'zod-validation-error'
 
 import { OptionsError } from '@/common/errors'

--- a/packages/validators/src/url/index.ts
+++ b/packages/validators/src/url/index.ts
@@ -63,22 +63,21 @@ export class UrlValidator {
    * Parses a URL string with a fallback option.
    *
    * @param url - The URL to validate
-   * @param fallbackUrl - The fallback URL to return if the URL is invalid. This is NOT validated.
+   * @param fallbackUrl - The fallback URL to return if the URL is invalid.
    * @throws {@link UrlValidationError} if the URL is invalid and fallbackUrl is not provided.
    * @returns The URL object if the URL is valid, else the fallbackUrl (if provided).
    *
    * @public
    */
-  parse<T extends string | URL>(url: string, fallbackUrl: T): URL | T
+  parse(url: string, fallbackUrl: string | URL): URL
   parse(url: string): URL
   parse(url: string, fallbackUrl: undefined): URL
-  parse<T extends string | URL>(url: string, fallbackUrl?: T): URL | T {
+  parse(url: string, fallbackUrl?: string | URL): URL {
     try {
       return this.#parse(url)
     } catch (error) {
       if (error instanceof UrlValidationError && fallbackUrl !== undefined) {
         // URL validation failed, return the fallback URL
-        // This is NOT validated.
         return this.#parse(fallbackUrl instanceof URL ? fallbackUrl.href : fallbackUrl)
       }
       // otherwise rethrow
@@ -90,16 +89,16 @@ export class UrlValidator {
    * Parses a URL string and returns the pathname with a fallback option.
    *
    * @param url - The URL to validate and extract pathname from
-   * @param fallbackUrl - The fallback URL to use if the URL is invalid. This is NOT validated.
+   * @param fallbackUrl - The fallback URL to use if the URL is invalid.
    * @throws {@link UrlValidationError} if the URL is invalid and fallbackUrl is not provided.
    * @returns The pathname of the URL or the fallback URL
    *
    * @public
    */
-  parsePathname<T extends string | URL>(url: string, fallbackUrl: T): string
+  parsePathname(url: string, fallbackUrl: string | URL): string
   parsePathname(url: string): string
   parsePathname(url: string, fallbackUrl: undefined): string
-  parsePathname<T extends string | URL>(url: string, fallbackUrl?: T): string {
+  parsePathname(url: string, fallbackUrl?: string | URL): string {
     const parsedUrl = fallbackUrl ? this.parse(url, fallbackUrl) : this.parse(url)
     if (parsedUrl instanceof URL) return parsedUrl.pathname
     return parsedUrl

--- a/packages/validators/src/url/index.ts
+++ b/packages/validators/src/url/index.ts
@@ -1,4 +1,4 @@
-import { ZodError, ZodSchema, ZodTypeDef } from 'zod'
+import { string, ZodError, ZodSchema, ZodTypeDef } from 'zod'
 import { fromError } from 'zod-validation-error'
 
 import { OptionsError } from '@/common/errors'
@@ -79,7 +79,7 @@ export class UrlValidator {
       if (error instanceof UrlValidationError && fallbackUrl !== undefined) {
         // URL validation failed, return the fallback URL
         // This is NOT validated.
-        return fallbackUrl
+        return this.#parse(fallbackUrl instanceof URL ? fallbackUrl.href : fallbackUrl)
       }
       // otherwise rethrow
       throw error


### PR DESCRIPTION
## Context

Currently, there's a common pattern across multiple codebases for handling redirect URLs:

```typescript
const validator = new UrlValidator({
  baseOrigin: new URL(baseUrl).origin,
  whitelist: {
    protocols: ['http', 'https'],
    hosts: [new URL(baseUrl).host],
  }
})

export const callbackUrlSchema = z
  .string()
  .optional()
  .default(RECORDINGS)
  .transform((url, ctx) => {
    try {
      return validator.parse(url)
    } catch (error) {
      ctx.addIssue({
        code: z.ZodIssueCode.custom,
        message: (error as Error).message,
      })
      return z.NEVER
    }
  })
  .catch(new URL(RECORDINGS, baseUrl))

...

await router.push(callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]))

...
```

## Changes
This PR introduces three key improvements to our URL validation and redirection process:
1. New `RelUrlValidator` Class
Simplifies the creation of UrlValidator with sensible defaults
Usage: `new RelUrlValidator(origin: string | URL)`
2. Enhanced `UrlValidator.parse(..., fallbackUrl: string | URL)`
Adds a `fallbackUrl` parameter
Eliminates the need to use `callbackUrlSchema`
3. `parsePathname` method
Introduces `UrlValidator.parsePathname(...)` that can be directly assigned to `window.location.pathname`

## Example usage
```typescript
const validator = new RelUrlValidator(baseUrl)
window.location.pathname = validator.parsePathname(router.query['redirect'], '/home'))
```