### PR TITLE
fix: parse arg typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 *.pem
 .vscode/
 .eslintcache
+.idea/

--- a/etc/starter-kitty-validators.api.md
+++ b/etc/starter-kitty-validators.api.md
@@ -22,51 +22,51 @@ export const createUrlSchema: (options?: UrlValidatorOptions) => ZodSchema<URL, 
 // @public
 export interface EmailValidatorOptions {
     domains?: {
-        domain: string;
-        includeSubdomains?: boolean;
-    }[];
+        domain: string
+        includeSubdomains?: boolean
+    }[]
 }
 
 // @public
 export class OptionsError extends Error {
-    constructor(message: string);
+    constructor(message: string)
 }
 
 // @public
 export interface PathValidatorOptions {
-    basePath: string;
+    basePath: string
 }
 
 // @public
 export class RelUrlValidator extends UrlValidator {
-    constructor(origin: string | URL);
+    constructor(origin: string | URL)
 }
 
 // @public
 export class UrlValidationError extends Error {
-    constructor(message: string);
+    constructor(message: string)
 }
 
 // @public
 export class UrlValidator {
-    constructor(options?: UrlValidatorOptions);
-    parse(url: string, fallbackUrl: string | URL): URL;
+    constructor(options?: UrlValidatorOptions)
+    parse(url: any, fallbackUrl: string | URL): URL
     // (undocumented)
-    parse(url: string): URL;
+    parse(url: any): URL
     // (undocumented)
-    parse(url: string, fallbackUrl: undefined): URL;
-    parsePathname(url: string, fallbackUrl: string | URL): string;
+    parse(url: any, fallbackUrl: undefined): URL
+    parsePathname(url: any, fallbackUrl: string | URL): string
     // (undocumented)
-    parsePathname(url: string): string;
+    parsePathname(url: any): string
     // (undocumented)
-    parsePathname(url: string, fallbackUrl: undefined): string;
+    parsePathname(url: any, fallbackUrl: undefined): string
 }
 
 // @public
 export interface UrlValidatorOptions {
-    baseOrigin?: string;
+    baseOrigin?: string
     // Warning: (ae-forgotten-export) The symbol "UrlValidatorWhitelist" needs to be exported by the entry point index.d.ts
-    whitelist?: UrlValidatorWhitelist;
+    whitelist?: UrlValidatorWhitelist
 }
 
 ```

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/src/__tests__/url.test.ts
+++ b/packages/validators/src/__tests__/url.test.ts
@@ -36,6 +36,12 @@ describe('UrlValidator with default options', () => {
     expect(() => validator.parse('javascript&colonalert(/xss/)').protocol).toThrow(UrlValidationError)
     expect(() => validator.parse('javascript:alert(/xss/)')).toThrow(UrlValidationError)
   })
+
+  it('should throw an error when given an invalid type', () => {
+    expect(() => validator.parse(123)).toThrow(UrlValidationError)
+    expect(() => validator.parse(undefined)).toThrow(UrlValidationError)
+    expect(() => validator.parse(['1', '2'])).toThrow(UrlValidationError)
+  })
 })
 
 describe('UrlValidator with custom protocol whitelist', () => {

--- a/packages/validators/src/url/index.ts
+++ b/packages/validators/src/url/index.ts
@@ -13,6 +13,8 @@ import { toSchema } from '@/url/schema'
  * @public
  */
 export class UrlValidator {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  // parse functions perform type coercion, so input can be any
   private schema
 
   /**
@@ -46,8 +48,8 @@ export class UrlValidator {
    *
    * @internal
    */
-  #parse(url: string): URL {
-    const result = this.schema.safeParse(url)
+  #parse(url: any): URL {
+    const result = url instanceof URL ? this.schema.safeParse(url.href) : this.schema.safeParse(url)
     if (result.success) {
       return result.data
     }
@@ -69,10 +71,10 @@ export class UrlValidator {
    *
    * @public
    */
-  parse(url: string, fallbackUrl: string | URL): URL
-  parse(url: string): URL
-  parse(url: string, fallbackUrl: undefined): URL
-  parse(url: string, fallbackUrl?: string | URL): URL {
+  parse(url: any, fallbackUrl: string | URL): URL
+  parse(url: any): URL
+  parse(url: any, fallbackUrl: undefined): URL
+  parse(url: any, fallbackUrl?: string | URL): URL {
     try {
       return this.#parse(url)
     } catch (error) {
@@ -95,10 +97,10 @@ export class UrlValidator {
    *
    * @public
    */
-  parsePathname(url: string, fallbackUrl: string | URL): string
-  parsePathname(url: string): string
-  parsePathname(url: string, fallbackUrl: undefined): string
-  parsePathname(url: string, fallbackUrl?: string | URL): string {
+  parsePathname(url: any, fallbackUrl: string | URL): string
+  parsePathname(url: any): string
+  parsePathname(url: any, fallbackUrl: undefined): string
+  parsePathname(url: any, fallbackUrl?: string | URL): string {
     const parsedUrl = fallbackUrl ? this.parse(url, fallbackUrl) : this.parse(url)
     if (parsedUrl instanceof URL) return parsedUrl.pathname
     return parsedUrl

--- a/packages/validators/src/url/index.ts
+++ b/packages/validators/src/url/index.ts
@@ -14,7 +14,7 @@ import { toSchema } from '@/url/schema'
  */
 export class UrlValidator {
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  // parse functions perform type coercion, so input can be any
+  // parse functions perform type checking, so input can be any
   private schema
 
   /**
@@ -42,7 +42,7 @@ export class UrlValidator {
   /**
    * Parses a URL string
    *
-   * @param url - The URL to validate
+   * @param url - The URL to validate, expects string | URL
    * @throws {@link UrlValidationError} if the URL is invalid.
    * @returns The URL object if the URL is valid
    *
@@ -64,7 +64,7 @@ export class UrlValidator {
   /**
    * Parses a URL string with a fallback option.
    *
-   * @param url - The URL to validate
+   * @param url - The URL to validate, expects string | URL
    * @param fallbackUrl - The fallback URL to return if the URL is invalid.
    * @throws {@link UrlValidationError} if the URL is invalid and fallbackUrl is not provided.
    * @returns The URL object if the URL is valid, else the fallbackUrl (if provided).
@@ -90,7 +90,7 @@ export class UrlValidator {
   /**
    * Parses a URL string and returns the pathname with a fallback option.
    *
-   * @param url - The URL to validate and extract pathname from
+   * @param url - The URL to validate and extract pathname from, expects string | URL
    * @param fallbackUrl - The fallback URL to use if the URL is invalid.
    * @throws {@link UrlValidationError} if the URL is invalid and fallbackUrl is not provided.
    * @returns The pathname of the URL or the fallback URL

--- a/precommit.sh
+++ b/precommit.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# ANSI colour codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Colour
+
+# Function to print error messages
+print_error() {
+    echo -e "${RED}[ERROR  ] $1${NC}"
+}
+
+# Function to print success messages
+print_success() {
+    echo -e "${GREEN}[SUCCESS] $1${NC}"
+}
+
+# Run initial commands
+pnpm lint:fix || { print_error "pnpm lint:fix failed"; exit 1; }
+pnpm lint || { print_error "pnpm lint failed"; exit 1; }
+pnpm build || { print_error "pnpm build failed"; exit 1; }
+pnpm format || { print_error "pnpm format failed"; exit 1; }
+pnpm format:check || { print_error "pnpm format:check failed"; exit 1; }
+
+# Change directory to packages
+cd packages || exit 1
+
+# Variable to track API Extractor failures
+api_extractor_failure=0
+
+# Loop through each folder that doesn't end with -config
+for dir in */; do
+    if [[ ! $dir == *-config/ ]]; then
+        echo "Processing $dir"
+        (
+            cd "$dir" || exit 1
+            pnpx @microsoft/api-extractor run --verbose
+        )
+        if [ $? -ne 0 ]; then
+            print_error "api-extractor failed for $dir"
+            api_extractor_failure=1
+        fi
+    fi
+done
+
+if [ $api_extractor_failure -eq 0 ]; then
+    print_success "All API Extractor operations completed successfully"
+else
+    print_error "One or more API Extractor operations failed"
+    exit 1
+fi
+
+echo "----------------------------------------"
+echo "Checking package.json modifications:"
+echo "----------------------------------------"
+
+# Check if package.json has been modified in each relevant folder
+package_json_modified=0
+for dir in */; do
+    if [[ ! $dir == *-config/ ]]; then
+        if git diff --quiet HEAD -- "$dir/package.json"; then
+            echo -e "${RED}package.json in $dir has NOT been modified${NC}"
+        else
+            echo -e "${GREEN}package.json in $dir has been modified${NC}"
+            package_json_modified=1
+        fi
+    fi
+done
+
+if [ $package_json_modified -eq 0 ]; then
+    print_error "No package.json was modified"
+    exit 1
+fi
+
+# If we've made it this far, all checks have passed
+echo "----------------------------------------"
+print_success "Pre-commit checks all succeeded!"
+echo "----------------------------------------"
+exit 0


### PR DESCRIPTION
Previously `parse` and `parsePathname` required a `string` as the first argument.
However, since we perform type checking via Zod under the hood, we can loosen this to `any`.

This will simplify
```typescript
const url: string | string[] | undefined = router.query['redirect']
const redirectUrl = url ? String(url) : '/home'
router.push(validator.parse(redirectUrl, '/home'))
```

to

```typescript
router.push(validator.parse(router.query['redirect'], '/home'))
```

Also added a precommit script, which should catch CI issues in advance
