### PR TITLE
fix: precommit api doc check

### DIFF
--- a/etc/starter-kitty-validators.api.md
+++ b/etc/starter-kitty-validators.api.md
@@ -22,51 +22,51 @@ export const createUrlSchema: (options?: UrlValidatorOptions) => ZodSchema<URL, 
 // @public
 export interface EmailValidatorOptions {
     domains?: {
-        domain: string
-        includeSubdomains?: boolean
-    }[]
+        domain: string;
+        includeSubdomains?: boolean;
+    }[];
 }
 
 // @public
 export class OptionsError extends Error {
-    constructor(message: string)
+    constructor(message: string);
 }
 
 // @public
 export interface PathValidatorOptions {
-    basePath: string
+    basePath: string;
 }
 
 // @public
 export class RelUrlValidator extends UrlValidator {
-    constructor(origin: string | URL)
+    constructor(origin: string | URL);
 }
 
 // @public
 export class UrlValidationError extends Error {
-    constructor(message: string)
+    constructor(message: string);
 }
 
 // @public
 export class UrlValidator {
-    constructor(options?: UrlValidatorOptions)
-    parse(url: any, fallbackUrl: string | URL): URL
+    constructor(options?: UrlValidatorOptions);
+    parse(url: any, fallbackUrl: string | URL): URL;
     // (undocumented)
-    parse(url: any): URL
+    parse(url: any): URL;
     // (undocumented)
-    parse(url: any, fallbackUrl: undefined): URL
-    parsePathname(url: any, fallbackUrl: string | URL): string
+    parse(url: any, fallbackUrl: undefined): URL;
+    parsePathname(url: any, fallbackUrl: string | URL): string;
     // (undocumented)
-    parsePathname(url: any): string
+    parsePathname(url: any): string;
     // (undocumented)
-    parsePathname(url: any, fallbackUrl: undefined): string
+    parsePathname(url: any, fallbackUrl: undefined): string;
 }
 
 // @public
 export interface UrlValidatorOptions {
-    baseOrigin?: string
+    baseOrigin?: string;
     // Warning: (ae-forgotten-export) The symbol "UrlValidatorWhitelist" needs to be exported by the entry point index.d.ts
-    whitelist?: UrlValidatorWhitelist
+    whitelist?: UrlValidatorWhitelist;
 }
 
 ```

--- a/precommit.sh
+++ b/precommit.sh
@@ -18,9 +18,9 @@ print_success() {
 # Run initial commands
 pnpm lint:fix || { print_error "pnpm lint:fix failed"; exit 1; }
 pnpm lint || { print_error "pnpm lint failed"; exit 1; }
-pnpm build || { print_error "pnpm build failed"; exit 1; }
 pnpm format || { print_error "pnpm format failed"; exit 1; }
 pnpm format:check || { print_error "pnpm format:check failed"; exit 1; }
+pnpm turbo build --force || { print_error "pnpm turbo build --force failed"; exit 1; }
 
 # Change directory to packages
 cd packages || exit 1


### PR DESCRIPTION
The precommit script succeeded but the CI still failed.

The issue is that in the precommit script, the prettier `format` command ran after the build, causing formatting to be applied to build artifacts `dist/`. api-extractor extracts the API from the build artifacts, causing subtle differences in the documentation (literally just semicolons). api-extractor detects this as an API drift, which is raised as a warning, causing the CI to fail.

Furthermore, due to the usage of `turbo` and its caching, subsequent `pnpm build` does not cause a rebuild even though `dist/` has been prettier'd, causing api-extractor to not detect any drift locally, hence passing the precommit script.