### PR TITLE
fix: add interception route check

### DIFF
--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/src/url/nextjs-dynamic-route.ts
+++ b/packages/validators/src/url/nextjs-dynamic-route.ts
@@ -1,0 +1,17 @@
+// regex from https://github.com/vercel/next.js/blob/8cb8edb686ec8ddf7e24c69545d11175fcb9df02/packages/next/src/shared/lib/router/utils/is-dynamic.ts#L7
+const DYNAMIC_ROUTE_SEGMENT_REGEX = /\/\[[^/]+?\](?=\/|$)/
+
+// from https://github.com/vercel/next.js/blob/94bda4995ee5ea0bb5b73288d21918ceeb2b35be/packages/next/src/server/lib/interception-routes.ts#L11
+function isInterceptionRouteAppPath(path: string): boolean {
+  const INTERCEPTION_ROUTE_MARKERS = ['(..)(..)', '(.)', '(..)', '(...)'] as const
+
+  return path.split('/').find(segment => INTERCEPTION_ROUTE_MARKERS.find(m => segment.startsWith(m))) !== undefined
+}
+
+export const isDynamicRoute = (url: URL): boolean => {
+  const route = url.pathname
+  if (isInterceptionRouteAppPath(route)) {
+    return true
+  }
+  return DYNAMIC_ROUTE_SEGMENT_REGEX.test(route)
+}

--- a/packages/validators/src/url/utils.ts
+++ b/packages/validators/src/url/utils.ts
@@ -1,8 +1,7 @@
 import { UrlValidationError } from '@/url/errors'
+import { isDynamicRoute } from '@/url/nextjs-dynamic-route'
 import { UrlValidatorWhitelist } from '@/url/options'
 
-// regex from https://github.com/vercel/next.js/blob/8cb8edb686ec8ddf7e24c69545d11175fcb9df02/packages/next/src/shared/lib/router/utils/is-dynamic.ts#L7
-const DYNAMIC_ROUTE_SEGMENT_REGEX = /\/\[[^/]+?\](?=\/|$)/
 const IS_NOT_HOSTNAME_REGEX = /[^.]+\.[^.]+/g
 
 export const resolveRelativeUrl = (url: string, baseOrigin?: URL): URL => {
@@ -25,10 +24,6 @@ export const resolveRelativeUrl = (url: string, baseOrigin?: URL): URL => {
     throw new UrlValidationError(`Invalid URL: ${url} is not on the same origin as base URL ${baseOrigin.href}`)
   }
   return normalizedUrl
-}
-
-export const isDynamicRoute = (url: URL): boolean => {
-  return DYNAMIC_ROUTE_SEGMENT_REGEX.test(url.pathname)
 }
 
 export const isSafeUrl = (url: URL, whitelist: UrlValidatorWhitelist) => {


### PR DESCRIPTION
## Context

In a recent VAPT on `care360`, it was discovered that an open redirect is still possible by using an undocumented feature (interception routes interpolation) (issue labelled as `GTA-55-008`).

## Approach

In this version bump, I have ported the check for interception routes into the validation logic.
This should block the the undocumented feature.
In the next version bump, a strict character whitelist will be enforced by default, with an option to override it.

## Risk

This will break existing routes that contain `(.) or (..) or (...) or (..)(..)`.

## Testing

The fix can be verified simply by visiting the links below and checking if the open redirect can still be triggered.


Email: `any@open.gov.sg`
OTP: `123123`

[[v1.2.10 open redirect poc]](https://starter-kit-vercel-git-sk-1-2-10-zhongliang02s-projects.vercel.app/sign-in?callbackUrl=https://starter-kit-vercel-git-sk-1-2-10-zhongliang02s-projects.vercel.app/[[x]]http:example.com/(.)[y]/?x%26y) [[deploy src]](https://github.com/zhongliang02/starter-kit-vercel/commit/af9c0e5f4af312788425e9278699c624ed072ef1)
[[v1.2.11 poc no longer works]](https://starter-kit-vercel-git-sk-1-2-11-exp01-zhongliang02s-projects.vercel.app/sign-in?callbackUrl=https://starter-kit-vercel-git-sk-1-2-11-exp01-zhongliang02s-projects.vercel.app/[[x]]http:example.com/(.)[y]/?x%26y) [[deploy src]](https://github.com/zhongliang02/starter-kit-vercel/commit/8dd6f9b88bb3cdd9f9b7639b6367567aa7973f43)

VAPT vendor says [[link]](https://opengovproducts.slack.com/archives/C084HDV214L/p1736876792568119?thread_ts=1736250550.201479&cid=C084HDV214L)
> most likely resolves the issue. At least for the most recent Next.js versions. There might be older versions where the fix doesn't work.