### PR TITLE
chore(validators): add zod v4 compat to package

### DIFF
--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-validators",
-  "version": "1.2.14",
+  "version": "1.3.0-beta.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -52,12 +52,15 @@
     "test": "vitest",
     "ci:report": "api-extractor run --verbose"
   },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
+  },
   "dependencies": {
     "email-addresses": "^5.0.0",
-    "zod": "^3.23.8",
-    "zod-validation-error": "^3.3.0"
+    "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {
+    "zod": "^3.25.0 || ^4.0.0",
     "@opengovsg/eslint-config-starter-kitty": "workspace:*",
     "@opengovsg/prettier-config-starter-kitty": "workspace:*",
     "@swc/core": "^1.6.13",

--- a/packages/validators/src/__tests__/email.test.ts
+++ b/packages/validators/src/__tests__/email.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ZodError } from 'zod'
+import { ZodError } from 'zod/v4'
 
 import { OptionsError } from '@/common/errors'
 import { createEmailSchema } from '@/index'

--- a/packages/validators/src/__tests__/path.test.ts
+++ b/packages/validators/src/__tests__/path.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { describe, expect, it } from 'vitest'
-import { ZodError } from 'zod'
+import { ZodError } from 'zod/v4'
 
 import { OptionsError } from '@/common/errors'
 import { createPathSchema } from '@/index'

--- a/packages/validators/src/__tests__/url.test.ts
+++ b/packages/validators/src/__tests__/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ZodError } from 'zod'
+import { ZodError } from 'zod/v4'
 
 import { OptionsError } from '@/common/errors'
 import { createUrlSchema, RelUrlValidator, UrlValidator } from '@/index'

--- a/packages/validators/src/email/index.ts
+++ b/packages/validators/src/email/index.ts
@@ -1,4 +1,4 @@
-import { ZodSchema } from 'zod'
+import { z } from 'zod/v4'
 import { fromError } from 'zod-validation-error'
 
 import { OptionsError } from '@/common/errors'
@@ -14,7 +14,7 @@ import { toSchema } from '@/email/schema'
  *
  * @public
  */
-export const createEmailSchema = (options: EmailValidatorOptions = {}): ZodSchema<string> => {
+export const createEmailSchema = (options: EmailValidatorOptions = {}): z.ZodType<string> => {
   const result = optionsSchema.safeParse(options)
   if (result.success) {
     return toSchema(result.data)

--- a/packages/validators/src/email/options.ts
+++ b/packages/validators/src/email/options.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 /**
  * The options to use for email validation.

--- a/packages/validators/src/email/schema.ts
+++ b/packages/validators/src/email/schema.ts
@@ -1,5 +1,5 @@
 import { ParsedMailbox, parseOneAddress } from 'email-addresses'
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { ParsedEmailValidatorOptions } from '@/email/options'
 import { isValidEmail } from '@/email/utils'

--- a/packages/validators/src/path/index.ts
+++ b/packages/validators/src/path/index.ts
@@ -1,4 +1,4 @@
-import { ZodSchema } from 'zod'
+import { z } from 'zod/v4'
 import { fromError } from 'zod-validation-error'
 
 import { OptionsError } from '@/common/errors'
@@ -14,7 +14,7 @@ import { toSchema } from '@/path/schema'
  *
  * @public
  */
-export const createPathSchema = (options: PathValidatorOptions): ZodSchema<string> => {
+export const createPathSchema = (options: PathValidatorOptions): z.ZodType<string> => {
   const result = optionsSchema.safeParse(options)
   if (result.success) {
     return toSchema(result.data)

--- a/packages/validators/src/path/options.ts
+++ b/packages/validators/src/path/options.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 /**
  * The options to use for path validation.

--- a/packages/validators/src/path/schema.ts
+++ b/packages/validators/src/path/schema.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { ParsedPathValidatorOptions } from '@/path/options'
 import { isSafePath } from '@/path/utils'

--- a/packages/validators/src/url/index.ts
+++ b/packages/validators/src/url/index.ts
@@ -1,4 +1,4 @@
-import { ZodError, ZodSchema, ZodTypeDef } from 'zod'
+import { z } from 'zod/v4'
 import { fromError } from 'zod-validation-error'
 
 import { OptionsError } from '@/common/errors'
@@ -53,7 +53,7 @@ export class UrlValidator {
     if (result.success) {
       return result.data
     }
-    if (result.error instanceof ZodError) {
+    if (result.error instanceof z.ZodError) {
       throw new UrlValidationError(fromError(result.error).toString())
     } else {
       // should only be UrlValidationError
@@ -144,7 +144,7 @@ export class RelUrlValidator extends UrlValidator {
  *
  * @public
  */
-export const createUrlSchema = (options: UrlValidatorOptions = defaultOptions): ZodSchema<URL, ZodTypeDef, string> => {
+export const createUrlSchema = (options: UrlValidatorOptions = defaultOptions): z.ZodType<URL, string> => {
   const result = optionsSchema.safeParse({ ...defaultOptions, ...options })
   if (result.success) {
     return toSchema(result.data)

--- a/packages/validators/src/url/options.ts
+++ b/packages/validators/src/url/options.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 export const lowercase = 'abcdefghijklmnopqrstuvwxyz'
 export const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/packages/validators/src/url/schema.ts
+++ b/packages/validators/src/url/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { ParsedUrlValidatorOptions } from '@/url/options'
 import { createAllowedCharsSchema, getErrorMessage, IS_NOT_HOSTNAME_REGEX, resolveRelativeUrl } from '@/url/utils'

--- a/packages/validators/src/url/utils.ts
+++ b/packages/validators/src/url/utils.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { UrlValidationError } from '@/url/errors'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,12 +101,9 @@ importers:
       email-addresses:
         specifier: ^5.0.0
         version: 5.0.0
-      zod:
-        specifier: ^3.23.8
-        version: 3.23.8
       zod-validation-error:
-        specifier: ^3.3.0
-        version: 3.3.0(zod@3.23.8)
+        specifier: ^5.0.0
+        version: 5.0.0(zod@4.3.6)
     devDependencies:
       '@opengovsg/eslint-config-starter-kitty':
         specifier: workspace:*
@@ -129,6 +126,9 @@ importers:
       vitest:
         specifier: ^4.0.6
         version: 4.0.6(@types/node@20.19.24)(yaml@2.4.5)
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 4.3.6
 
 packages:
 
@@ -2639,14 +2639,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-validation-error@3.3.0:
-    resolution: {integrity: sha512-Syib9oumw1NTqEv4LT0e6U83Td9aVRk9iTXPUQr1otyV1PuXQKOvOwhMNqZIq5hluzHP2pMgnOmHEo7kPdI2mw==}
+  zod-validation-error@5.0.0:
+    resolution: {integrity: sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.18.0
+      zod: ^3.25.0 || ^4.0.0
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5374,10 +5374,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@3.3.0(zod@3.23.8):
+  zod-validation-error@5.0.0(zod@4.3.6):
     dependencies:
-      zod: 3.23.8
+      zod: 4.3.6
 
-  zod@3.23.8: {}
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
- Move zod from dependencies to peerDependencies (^3.25.0 || ^4.0.0)
- Update all imports from 'zod' to 'zod/v4' permanent subpath
- Replace ZodSchema/ZodTypeDef with z.ZodType (v4 simplified generics)
- Update zod-validation-error from ^3.3.0 to ^5.0.0
