### PR TITLE
fix: detect prerelease tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,18 @@ jobs:
       - name: 🔨 Build
         run: pnpm build
 
+      - name: Determine npm dist-tag
+        id: dist-tag
+        run: |
+          # Extract version from git tag (e.g. "validators/v1.3.0-beta.0" → "1.3.0-beta.0")
+          VERSION="${GITHUB_REF_NAME#*/v}"
+          # Extract prerelease identifier (e.g. "1.3.0-beta.0" → "beta")
+          PRERELEASE=$(echo "$VERSION" | sed -n 's/^[0-9]*\.[0-9]*\.[0-9]*-\([a-zA-Z]*\).*/\1/p')
+          if [ -n "$PRERELEASE" ]; then
+            echo "tag=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to NPM
-        run: pnpm -r publish --no-git-checks --tag latest --access public
+        run: pnpm -r publish --no-git-checks --tag ${{ steps.dist-tag.outputs.tag }} --access public


### PR DESCRIPTION
## Summary
- Release workflow now auto-detects prerelease versions (e.g. `1.3.0-beta.0`) from the git tag and uses the prerelease identifier (`beta`, `rc`, `alpha`, etc.) as the npm dist-tag
- Non-prerelease tags continue to publish with `--tag latest`
- Enables publishing beta/rc versions without affecting the `latest` tag on npm

## Test plan
- [x] Verified tag parsing logic in shell for: `beta.0`, `rc.1`, `alpha.3`, stable versions, and branch names