### PR TITLE
fix: skip docs publish and refresh API report

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opengovsg/starter-kitty-docs",
+  "private": true,
   "description": "Documentation for Starter Kitty",
   "main": "index.js",
   "scripts": {

--- a/etc/starter-kitty-validators.api.md
+++ b/etc/starter-kitty-validators.api.md
@@ -6,18 +6,16 @@
 
 /// <reference types="node" />
 
-import { z } from 'zod';
-import { ZodSchema } from 'zod';
-import { ZodTypeDef } from 'zod';
+import { z } from 'zod/v4';
 
 // @public
-export const createEmailSchema: (options?: EmailValidatorOptions) => ZodSchema<string>;
+export const createEmailSchema: (options?: EmailValidatorOptions) => z.ZodType<string>;
 
 // @public
-export const createPathSchema: (options: PathValidatorOptions) => ZodSchema<string>;
+export const createPathSchema: (options: PathValidatorOptions) => z.ZodType<string>;
 
 // @public
-export const createUrlSchema: (options?: UrlValidatorOptions) => ZodSchema<URL, ZodTypeDef, string>;
+export const createUrlSchema: (options?: UrlValidatorOptions) => z.ZodType<URL, string>;
 
 // @public
 export interface EmailValidatorOptions {


### PR DESCRIPTION
Two CI fixes after the changesets + Zod v4 migration.

## 1. Release job — skip docs publish

The release job [failed](https://github.com/opengovsg/starter-kitty/actions/runs/26938920657) after `@opengovsg/starter-kitty-validators@1.3.0` published, with:

```
ERR_PNPM_PACKAGE_VERSION_NOT_FOUND undefined
Package version is not defined in the package.json.
```

`apps/docs` (`@opengovsg/starter-kitty-docs`) is in the pnpm workspace (`apps/*`) but is a VitePress site, not a publishable package. With no `version` and no `private` flag, `changeset publish` tried to publish it at version `undefined`. Fix: add `"private": true`, matching `eslint-config` and `prettier-config`.

> The orphaned `1.3.0` git tag + GitHub release from the failed run were already created manually; npm was already published.

## 2. Documentation job — refresh API report

The Documentation job [failed](https://github.com/opengovsg/starter-kitty/actions/runs/26938920560) at `pnpm ci:report`. The Zod v4 change updated the source (`import { z } from 'zod/v4'`, `z.ZodType`) but `etc/starter-kitty-validators.api.md` still described the v3 signatures (`ZodSchema`, `ZodTypeDef`). Regenerated the report so api-extractor's check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)