### PR TITLE
ci: create release PR with a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,22 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Mint a token from the reusable Changesets GitHub App so the Version
+      # Packages PR is created with a non-default identity. PRs/pushes made
+      # with the default GITHUB_TOKEN do NOT trigger workflows, so required
+      # checks (e.g. "Run tests") would never run on the release PR; an App
+      # token avoids that. See actions/create-github-app-token.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OGP_CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.OGP_CHANGESETS_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -93,5 +106,5 @@ jobs:
           version: pnpm version-packages
           publish: pnpm changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868


### PR DESCRIPTION
## Problem

The Changesets "Version Packages" PR is opened by the bot using the default `GITHUB_TOKEN`. GitHub deliberately does **not** trigger workflows for events created by `GITHUB_TOKEN` (to avoid recursive runs), so the required **`Run tests`** check never ran on that PR — making it un-mergeable without an org-admin bypass.

## Fix

Mint a token from a reusable org GitHub App (`actions/create-github-app-token@v3`) and use it for both `actions/checkout` and the `opengovsg/changesets-action` step. Because the release PR is then created under the App identity (not `GITHUB_TOKEN`), normal `pull_request` events fire and `Run tests` runs and passes — no bypass needed.

Only the `release` job changes; the `snapshot` job is untouched (it doesn't open PRs).

## Required setup (must exist before merge)

Org-level GitHub App + org secrets:

- `OGP_CHANGESETS_APP_ID`
- `OGP_CHANGESETS_APP_PRIVATE_KEY`

App permissions (least privilege): **Contents: read/write**, **Pull requests: read/write**. The App is org-owned and reusable across other Changesets repos.

> [!IMPORTANT]
> If the secrets are not configured, the `release` job's token step fails. Ensure the App is created, installed on this repo, and the two org secrets are set before merging.

## After merge

The Version Packages PR will be authored by the App bot, `Run tests` will run on it, and it can be merged normally without the admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)