### PR TITLE
feat(logging): add fixed-shape audit helper layer

### DIFF
--- a/.changeset/audit-helpers.md
+++ b/.changeset/audit-helpers.md
@@ -1,0 +1,12 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add the fixed-shape **audit helper layer** — `logger.audit.<category>.<event>`
+(ADR-0006) — with the first two categories, `authn` and `userManagement`. Each
+event has a type-enforced shape, stamps the Controlled `audit`/`category`/`event`
+wire fields, separates actor (scope `user_id`) from target
+(`context.target_user_id`), fires at a per-event `notice`/`warn`, and performs no
+value transformation (secrets are unrepresentable; PII is a sink concern). Each
+event's default message can be overridden via `messageOverride`. `.audit` is on
+the server `Logger` only (not `BasicLogger`), built lazily.

--- a/docs/adr/0005-no-redaction-in-base-logger.md
+++ b/docs/adr/0005-no-redaction-in-base-logger.md
@@ -16,7 +16,7 @@ Two technical facts make this much harder than it appears in the base logger:
 1. **pino `redact` is path/key-based only.** It censors values at enumerated
    object paths (`a.b.c`, `stuff[*].secret`, one wildcard per path) with a
    `censor` replacement. It has **no value/pattern matching** — it cannot find an
-   NRIC, email, or phone number by inspecting a *value*. So the PII half of the
+   NRIC, email, or phone number by inspecting a _value_. So the PII half of the
    proposal is impossible via `redact` by construction.
 
 2. **The base logger's `context` is arbitrary-shaped.** Business data is an
@@ -27,7 +27,7 @@ Two technical facts make this much harder than it appears in the base logger:
 Given (2), every in-base redaction strategy is a bad trade:
 
 - **Path-based (pino `redact`)** only catches the paths you enumerate, to one
-  wildcard's depth. Deeper secrets slip through — a *false sense of safety*,
+  wildcard's depth. Deeper secrets slip through — a _false sense of safety_,
   which is worse than none.
 - **Any-depth key redaction** needs a custom serializer that walks every log
   object on every line — a per-line CPU cost the package has deliberately
@@ -42,11 +42,14 @@ Given (2), every in-base redaction strategy is a bad trade:
 The base logger does **not** redact. No `redact` paths are baked into the
 default config, and no value-scrubbing is performed.
 
-Redaction is deferred to the planned **fixed-shape helper loggers** (the future
-direction in [ADR-0003](./0003-canonical-log-wire-schema.md)). Once a helper
-fixes the shape of its `context`, redaction becomes tractable: a small,
-enumerable set of known paths, complete coverage (no arbitrary depth), and
-bounded, predictable cost. That is where censoring secret keys belongs.
+Handling of secrets is deferred to the planned **fixed-shape helper loggers**
+(the future direction in [ADR-0003](./0003-canonical-log-wire-schema.md), now
+realised in [ADR-0007](./0007-fixed-shape-audit-helpers.md)). Once a helper fixes
+the shape of its `context`, secrets are handled not by _censoring_ but by
+_exclusion_: a secret simply is not a field, so it cannot be passed and cannot
+leak — stronger than path-based redaction and at zero cost. The helpers perform
+no value transformation (ADR-0007 records why an in-helper hashing leg was
+designed and rejected).
 
 PII, if and when it must be handled, belongs at the **sink** (e.g. Datadog
 Sensitive Data Scanner — centrally-defined pattern rules applied at ingestion,
@@ -63,9 +66,10 @@ Redaction is a safety net, not the mechanism that makes logging safe.
 - The cost of safe logging sits with the caller (don't log secrets/PII) and,
   later, with fixed-shape helpers and the sink — not with a per-line scrubber in
   the hot path.
-- When the fixed-shape helpers land, they own the curated, reviewed redaction
-  list (the "shared asset"), scoped to their known fields. This ADR should be
-  revisited then to point at that implementation.
+- The fixed-shape helpers (ADR-0007) keep secrets out **by shape** rather than
+  by a censor list, and leave PII to the sink. There is no curated redaction list
+  to own — the "shared asset" turned out to be the _closed event schemas_
+  themselves, which make secrets unrepresentable.
 - If a future need forces base-logger redaction despite the above (e.g. a
   compliance mandate), it reopens the performance trade in (2) explicitly,
   rather than being added silently.

--- a/docs/adr/0007-fixed-shape-audit-helpers.md
+++ b/docs/adr/0007-fixed-shape-audit-helpers.md
@@ -1,0 +1,250 @@
+# 7. Fixed-shape audit helpers
+
+Date: 2026-06-24
+Status: Accepted
+
+## Context
+
+ADR-0003 and ADR-0005 both end by pointing at the same future direction:
+"fixed-shape helper loggers that standardise specific `context` shapes," layering
+_above_ the base. ADR-0005 in particular defers all redaction to them — once a
+helper fixes the shape of its `context`, redaction becomes a small, enumerable,
+bounded-cost problem instead of an arbitrary-depth one. This ADR is that layer.
+
+The driver is a compliance/audit standard: a **closed, externally-governed
+taxonomy** of auditable events (authentication & session, user & permission
+management, data access/movement/export, security-configuration changes, API
+usage, security failures), each with a required field set. This is not a grab-bag
+of "convenience helpers" — it is a curated set where every addition is a
+governance decision, not a developer convenience. The taxonomy itself lives in
+code and the README (it churns as the standard evolves); this ADR records the
+durable principles only.
+
+Two pressures shape the surface, the same pair ADR-0001 named: the API must be
+**ergonomic** (or engineers route around it and the structure is lost) and
+**queryable** (the lines feed dashboards, incident review, and a compliance
+audit trail). Layered on top is a third: the API should make it **obvious at the
+call site** that a call is a structure-enforced, compliance-weighted audit event,
+not a routine log line.
+
+## Decision
+
+### The layer owns only app-emitted events; it disclaims the rest
+
+The compliance matrix mixes three kinds of requirement, and only one is a helper:
+
+- **App-emitted fixed-shape events** (the six categories above) — the helper
+  layer. These are things the application _does_ and can log at the moment they
+  happen.
+- **Cross-cutting field requirements already met by the base** — "every line
+  carries a correlation/request ID" is already the base Scope fields
+  (`correlation_id`, `trace_id`); "source/destination addresses" are payload
+  fields on the data-movement events. Nothing to build.
+- **Operational / sink concerns the library cannot enforce** — centralised
+  storage, WORM/immutable retention, SSO-gated read access, DevOps-only write
+  access. A library emitting NDJSON to stdout has no leverage here; these belong
+  to the sink (Datadog) and infra/IAM, documented in an ops runbook, not shipped
+  as a method. Advertising them in the package surface would falsely imply the
+  code controls them.
+- **Detection, not emission** — "anomalous/high-volume API calls," "abnormal
+  usage patterns." The app does not know a call is anomalous at log time;
+  anomaly detection is a sink/SIEM monitor built _on top of_ the clean event
+  lines. The package's job is to emit those lines, not to judge them.
+
+Modelling the latter three as helpers would be a category error. The layer ships
+the first kind only.
+
+### `logger.audit.<category>.<event>(...)`
+
+A single `audit` namespace at the root of `Logger`, then category, then the
+specific event: `logger.audit.authn.loginFailed({ ... })`.
+
+- **`audit` stays as a root namespace** (not dropped, not flattened onto the
+  logger). It is the call-site expression of the wire marker the sink routes on
+  (see below), it announces the compliance-weighted subsystem at the call site,
+  and it is a single stable reservation on the deliberately-small `Logger`
+  surface (ADR-0001) rather than splicing six category names directly onto it.
+- **The category survives as a real path segment** for autocomplete-grouped
+  discovery across a ~6-category / ~20-event taxonomy, and as a wire facet.
+- **Naming rule: unambiguous over short.** A segment name _is_ the Datadog facet
+  value _and_ the codebase grep term, so there is no abbreviation-to-wire mapping
+  layer. Short is fine when unambiguous (`authn`, `mfa`, `pii`); ambiguous is
+  not, regardless of length (`auth` conflates authn/authz; `failed` does not say
+  what failed). Note `authz` is _not_ a safe mirror of `authn` here — it straddles
+  permission administration and access-enforcement decisions, which live in
+  different categories.
+
+### The event spec is the unit of the design
+
+Each event is a small spec — `{ category, level, payload-required fields,
+scope-read fields }` — and the rest of this ADR is how each column behaves. The
+taxonomy is a table of these specs. There is no "sensitive fields" column: the
+helper does not transform values (see Redaction below).
+
+### Field sourcing is per-event, split by timing relative to scope binding
+
+A required field is sourced one of two ways, decided per event:
+
+- **Payload-required (compile-enforced)** for events at or _upstream_ of identity
+  being established — `loginSucceeded`/`loginFailed` _produce_ `user_id`; they
+  cannot read it from a scope that does not have it yet.
+- **Scope-read (runtime-asserted)** for events _downstream_ of authentication —
+  `dataAccess`, `bulkExport`, `permissionChanged` run inside an already-scoped
+  request and read shared identity from the bound scope.
+
+So the same field (`user_id`) is payload-required for authn events and scope-read
+for post-auth events. Where a field is scope-read, the helper **asserts at
+runtime** that the required scope field is present and emits a diagnostic line
+(the Context-guard pattern) when it is not — turning a missing compliance field
+into a loud, queryable signal rather than a silent gap. A purely scope-reliant
+model (no payload, no assert) was rejected: it degrades "required field present"
+from a guarantee to a hope. A fully self-contained model (re-demand every field
+in the payload) was rejected too: it duplicates Scope facets and invites
+on-the-wire contradiction (`ip` in payload disagreeing with `client_ip`
+in scope).
+
+**`client_ip` / `user_agent` are _acknowledged_ at construction, _verified_ at
+emit — two complementary layers.** The base logger's request shape
+(`LoggerOptions`) makes `clientIp` and `userAgent` **required keys** (a compile
+error if omitted), so a request logger can never _silently forget_ client
+identity. But the values are `string | null | undefined` — a genuinely-missing
+header (`headers.get(...)` returns `null`) is passed explicitly — so the value
+may still be absent at emit. The scope-read assertion therefore _still fires_ its
+diagnostic when the value is missing, even on a request logger: compile-time
+guarantees the field was considered, runtime catches when it is actually absent.
+(On the **system** logger path — `createLogging(...).system(...)`, startup/jobs/
+cron — the fields don't exist at all, so the diagnostic also flags the mistake of
+emitting an interactive-auth audit there.) `user_id` is unaffected — it stays
+optional on both shapes, so its scope-read assertion (for admin events that
+require an actor) is likewise a genuine runtime check.
+
+**Required vs optional is decided by _architectural_ absence, not "not yet
+wired".** A field is optional only when it genuinely cannot exist for a class of
+the event — `session_id` is optional because stateless auth (e.g.
+`iron-session`) has no session, full stop. A field that merely _might not have
+been set up_ (a device fingerprint an app hasn't computed) is **not** made
+optional: that would let the compliance signal silently vanish, defeating the
+layer. Where a required signal is already carried by the base, the event
+**reuses the existing Scope field** rather than adding a payload field — the
+"device/browser fingerprint" requirement is satisfied by `user_agent` (always
+present for interactive logins) plus `device_id` (where a dedicated fingerprint
+is bound), scope-read, not a new `fingerprint` payload field. Truly
+fingerprint-less auth (machine-to-machine) is a _different category_ (API auth),
+not an optional hole in interactive login.
+
+### Canonical fields land at their canonical position; payload wins, mismatch is flagged
+
+When a payload field corresponds to a canonical wire field (`user_id`,
+`client_ip`, `device_id`), the helper **promotes it to that top-level
+position**, not into `context`. Burying `user_id` in `context.user_id` would file
+the login line under a different facet than every downstream line and break
+the very correlation category 7 requires. For authn events the payload is the
+authoritative source, so **payload wins** over any (unexpected) scope value of
+the same field, and a **mismatch emits a diagnostic** — silent disagreement on a
+compliance field is the failure mode to avoid.
+
+### `event` / `category` / `audit` are Controlled root fields, not context
+
+The helper stamps three new **Controlled** fields (logger-owned, caller cannot
+set them — the criterion for the tier, per ADR-0003): `event` (the specific
+event, e.g. `loginFailed`), `category` (the closed-taxonomy group, e.g. `authn`),
+and `audit: true` (the marker the sink routes audit lines to WORM/immutable
+storage on). They are conditional — present only on audit lines — which is no
+objection: `error` is already a conditional Controlled field.
+
+- `event` is **distinct from `action`**. `action` keeps its meaning — the calling
+  operation/function (the scoped leaf) — and `event` is the audited thing. They
+  coexist on a line (`action: "verifyOtp"`, `event: "loginFailed"`).
+- They are **not** placed in `context`. `context` is the app-owned, free-form bag
+  (ADR-0003); injecting reserved keys into it breaks tier integrity and collides
+  with app business keys (the reason `LogInput.context` already forbids `action`
+  and `error`). The cardinality worry that motivates `context` does not apply:
+  `category` and `event` are closed, low-cardinality enums and the marker is a
+  boolean — exactly the curated facets root-level indexing is for, not the open
+  bag ADR-0003 guards against.
+
+### Level is fixed per event, drawn from `{ notice, warn }`
+
+Severity is part of the event spec, not a call-site choice (which would let two
+call sites of the same event disagree). Most events are `notice` — "the audit
+rung" (ADR-0001). Security-relevant denials/failures (blocked export, denied
+privilege escalation, unauthorised-access attempt) are pinned to `warn`
+("something off but handled — the control fired"). The band is bounded on both
+sides: never below `notice` (audit lines must survive the retention floor — see
+ADR-0001's `level ≤ notice` invariant), and never `error` (an audit event is not
+an operation failure; a system error _during_ an audited action is logged
+separately via base `error()`).
+
+### Redaction: forbid secrets by shape, defer PII to the sink — the helper does not transform
+
+This is the ADR-0005 payoff, but it lands on **two** controls, not three. The
+helper performs **no value transformation** (no hashing, truncation, or
+censoring). Instead:
+
+1. **Forbid raw secrets by shape.** Passwords, raw tokens, and raw API keys are
+   simply _not fields_ — the type makes it impossible to pass them. This is
+   _stronger_ than the "censor secret keys" ADR-0005 anticipated: a field that
+   cannot be passed cannot leak, so there is nothing left to censor. "Don't log
+   secrets," enforced by the compiler, is the primary control.
+2. **Defer PII to the sink.** Identifiers that may be PII (`user_id`,
+   `client_ip`, `username`, …) stay raw in code and are scrubbed at the sink
+   (Datadog Sensitive Data Scanner) — by pattern, uniformly across base _and_
+   audit lines. The sink is the only place value-pattern scanning is affordable
+   and reliable (ADR-0005 rejected it on the hot path); doing it centrally also
+   covers the base lines a helper could never reach.
+
+An in-helper transform leg (deterministically hashing sensitive identifiers such
+as `session_id` or `username`) was designed and **rejected**:
+
+- It would have dragged a managed HMAC **key** (a pepper, plus rotation that
+  breaks cross-time correlation) into a package that deliberately reads no
+  secrets of its own — disproportionate machinery.
+- Hashing a **free-text identity** field like `username` is _self-defeating_: the
+  field exists so an investigator can read **who** acted; a hash blinds exactly
+  the reader it is logged for.
+- The remaining candidates are **not secrets by the layer's contract.**
+  `session_id`/`token_id` are defined as non-impersonatable _references_; if an
+  app's identifier can actually be replayed, hashing it before logging is the
+  app's responsibility (e.g. `iron-session` is stateless — the credential is the
+  sealed cookie, which is never a field, and any logged `sid` is app-minted).
+
+No dormant transform hook is shipped. A field-level transform would be added only
+as a real, user-invocable capability if a genuine must-log-but-must-mask field
+ever appears — not as dead infrastructure (YAGNI).
+
+### `.audit` lives on `Logger` only and is built lazily
+
+`.audit` is exposed on the full server `Logger`, **not** on `BasicLogger`
+(the shared client/server shape). Audit events are server-side — a browser
+cannot redact, reach the WORM sink, or legitimately assert these events — so the
+boundary is type-enforced: shared/client code cannot call audit helpers. The
+namespace is attached via a **lazy, memoised getter**: loggers are created
+per-request and the namespace is ~20 closures, so the common path (a request that
+emits no audit event) pays nothing, and audit requests build it once.
+
+## Consequences
+
+- The base logger is unchanged; the audit layer is strictly additive and lives
+  above it. ADR-0005 is updated to reflect that the helpers handle secrets by
+  _forbidding them in the shape_ rather than by maintaining a censor list.
+- Three new Controlled wire fields (`event`, `category`, `audit`) join the schema
+  documented in ADR-0003. They are conditional (audit lines only) and
+  low-cardinality, and the sink's WORM-routing / access-control rules (the
+  unenforceable category-8 requirements) key off `audit: true`.
+- "Required compliance field is present" is a **compile-time** guarantee for
+  payload-required fields and a **runtime-asserted, diagnostic-on-miss**
+  guarantee for scope-read fields — never silent.
+- The helper does no value transformation: secrets are unrepresentable (not
+  fields) and PII is a sink concern. This keeps the layer pure structure
+  enforcement and adds no key management to the package.
+- The taxonomy is a closed, governed set; adding an event is a deliberate change
+  to the spec table, not an ad-hoc call. The category list is intentionally kept
+  out of this ADR so the standard can evolve without ADR churn.
+- `audit` is the first of potentially several **sibling helper namespaces**.
+  Future non-audit, "good-to-have-logged" helpers (open taxonomy, low bar, no
+  compliance weight) get their _own_ top-level namespace
+  (e.g. `logger.track.*`), **not** a home under `audit` — the two families have
+  opposite governance (closed/governed/redacted/WORM vs open/convenience), and
+  merging them would dilute the audit set and forfeit the call-site and wire
+  ("what is an audit line?") clarity that `audit` provides. The sibling is named
+  when it first has members, not reserved speculatively.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,3 +16,4 @@ Files are numbered sequentially: `NNNN-kebab-case-title.md`.
 | [0004](./0004-scope-not-pino-child.md)          | Scoping is `scope`, not `child`              | Accepted |
 | [0005](./0005-no-redaction-in-base-logger.md)   | No redaction in the base logger              | Accepted |
 | [0006](./0006-pluggable-error-serialization.md) | Pluggable error serialisation; no error type | Accepted |
+| [0007](./0007-fixed-shape-audit-helpers.md)     | Fixed-shape audit helpers                    | Accepted |

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -5,6 +5,60 @@
 ```ts
 
 // @public
+export interface AccountCreatedInput extends AuditInputBase {
+    targetUserId: string;
+}
+
+// @public
+export interface AccountDeactivatedInput extends AuditInputBase {
+    reason?: string;
+    targetUserId: string;
+}
+
+// @public
+export interface AccountDeletedInput extends AuditInputBase {
+    targetUserId: string;
+}
+
+// @public
+export interface AccountModifiedInput extends AuditInputBase {
+    changedFields: string[];
+    targetUserId: string;
+}
+
+// @public
+export interface ApiKeyChangedInput extends AuditInputBase {
+    action: 'created' | 'rotated' | 'revoked';
+    keyId: string;
+    targetUserId: string;
+}
+
+// @public
+export type AuditContext = Record<string, unknown>;
+
+// @public
+export interface AuditInputBase {
+    context?: AuditContext;
+    messageOverride?: string;
+}
+
+// @public
+export interface AuditLogger {
+    authn: AuthnAudit;
+    userManagement: UserManagementAudit;
+}
+
+// @public
+export interface AuthnAudit {
+    loginFailed(input: LoginFailedInput): void;
+    loginSucceeded(input: LoginSucceededInput): void;
+    sessionCreated(input: SessionCreatedInput): void;
+    sessionTerminated(input: SessionTerminatedInput): void;
+    sessionTimedOut(input: SessionTimedOutInput): void;
+    tokenReused(input: TokenReusedInput): void;
+}
+
+// @public
 export interface BasicLogger<Input extends Partial<LogInput> = LogInput> {
     debug: (_: Omit<Input, 'error'>) => void;
     error: (_: Input) => void;
@@ -23,6 +77,7 @@ export const createLogging: (config: LoggingConfig) => CreateLogger;
 
 // @public
 export interface Logger {
+    readonly audit: AuditLogger;
     debug(input: Omit<LogInput, 'error'>): void;
     error(input: LogInput): void;
     info(input: Omit<LogInput, 'error'>): void;
@@ -61,6 +116,16 @@ export interface LoggingConfig {
 }
 
 // @public
+export interface LoginFailedInput extends AuditInputBase {
+    attemptCount: number;
+    privileged: boolean;
+    reason: string;
+    role?: string;
+    userId?: string;
+    username: string;
+}
+
+// @public
 export interface LogInput {
     action?: string;
     context?: {
@@ -74,10 +139,55 @@ export interface LogInput {
 }
 
 // @public
+export interface LoginSucceededInput extends AuditInputBase {
+    privileged: boolean;
+    role: string;
+    sessionId?: string;
+    userId: string;
+    username?: string;
+}
+
+// @public
 export type LogLevel = 'silent' | 'debug' | 'info' | 'notice' | 'warn' | 'error';
 
 // @public
+export interface MfaSettingChangedInput extends AuditInputBase {
+    change: string;
+    targetUserId: string;
+}
+
+// @public
+export interface PasswordResetInput extends AuditInputBase {
+    initiatedBy: 'self' | 'admin';
+    targetUserId: string;
+}
+
+// @public
+export interface RoleChangedInput extends AuditInputBase {
+    newRoles: string[];
+    oldRoles: string[];
+    targetUserId: string;
+}
+
+// @public
 export function serializeError(err: Error): Record<string, unknown>;
+
+// @public
+export interface SessionCreatedInput extends AuditInputBase {
+    sessionId: string;
+}
+
+// @public
+export interface SessionTerminatedInput extends AuditInputBase {
+    reason: string;
+    sessionId: string;
+}
+
+// @public
+export interface SessionTimedOutInput extends AuditInputBase {
+    sessionId: string;
+    userId: string;
+}
 
 // @public
 export interface SystemLoggerOptions {
@@ -89,6 +199,24 @@ export interface SystemLoggerOptions {
     source?: string | null;
     traceId?: string | null;
     userId?: string;
+}
+
+// @public
+export interface TokenReusedInput extends AuditInputBase {
+    sessionId?: string;
+    tokenId: string;
+}
+
+// @public
+export interface UserManagementAudit {
+    accountCreated(input: AccountCreatedInput): void;
+    accountDeactivated(input: AccountDeactivatedInput): void;
+    accountDeleted(input: AccountDeletedInput): void;
+    accountModified(input: AccountModifiedInput): void;
+    apiKeyChanged(input: ApiKeyChangedInput): void;
+    mfaSettingChanged(input: MfaSettingChangedInput): void;
+    passwordReset(input: PasswordResetInput): void;
+    roleChanged(input: RoleChangedInput): void;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -209,3 +209,101 @@ export const createBaseLogger = createLogging({
 The base logger does **not** reach into an error's `context` property. If you
 want an error's metadata in the queryable top-level `context`, pass it
 explicitly: `logger.error({ error, context: { ...} })`.
+
+## Audit events
+
+The server `Logger` carries an **`audit`** namespace for compliance-auditable
+business events — "who did what to which critical resource" — drawn from a
+**closed, governed taxonomy** (authentication, user management, data access, …).
+Unlike a routine log line, each audit event has a **fixed, type-enforced shape**:
+required fields are mandatory at compile time, shared identity (`user_id`,
+`client_ip`) is read from the bound scope, and the helper stamps three Controlled
+wire fields — `audit: true` (the marker your sink routes to WORM/immutable
+storage), `category`, and `event`.
+
+```ts
+const logger = createBaseLogger({
+  path: '/login',
+  traceId: req.headers.get('x-trace-id'),
+  clientIp: req.headers.get('cf-connecting-ip'),
+  userAgent: req.headers.get('user-agent'),
+})
+
+logger.scope({ action: 'verifyOtp' }).audit.authn.loginSucceeded({
+  userId: 'u_1',
+  role: 'admin',
+  privileged: true,
+  username: 'jane',
+  sessionId: 's_1',
+})
+```
+
+```json
+{
+  "level": "NOTICE",
+  "message": "Login succeeded",
+  "audit": true,
+  "category": "authn",
+  "event": "loginSucceeded",
+  "action": "verifyOtp",
+  "user_id": "u_1",
+  "client_ip": "1.2.3.4",
+  "context": { "role": "admin", "privileged": true, "username": "jane", "session_id": "s_1" }
+}
+```
+
+- **Call shape:** `logger.audit.<category>.<event>(input)`. `category` and `event`
+  are real path segments (autocomplete-grouped) **and** the wire facet values —
+  there is no abbreviation layer.
+- **Canonical facets are promoted**, not buried: `userId` becomes the top-level
+  `user_id`, not `context.user_id`. Event-specific fields land in `context`
+  (emitted `snake_case`).
+- **Level is fixed per event**, drawn from `{ notice, warn }` — most events are
+  `notice` (the audit rung), security-relevant denials are `warn`; never `error`
+  (an audit event is not an operation failure). Keep the production `level` at
+  `notice` or lower so audit lines survive (see **Retention** above).
+- **Server-only.** `audit` lives on the full `Logger`, not on `BasicLogger`, so
+  shared/client code cannot emit audit events. It is built lazily — a request
+  that emits none pays nothing.
+- **Secrets are unrepresentable by shape** — passwords, raw tokens, and raw API
+  keys are simply never fields. Identifiers that may be PII (`user_id`,
+  `username`, …) stay raw and are scrubbed at the **sink**, not in-process.
+- **Scope-read fields are asserted at emit:** when an event reads `user_id` /
+  `client_ip` from the scope and it is missing, the helper emits a loud
+  diagnostic line rather than a silently-incomplete audit record.
+
+See [ADR-0007](../../docs/adr/0007-fixed-shape-audit-helpers.md) for the design.
+Every input additionally accepts `context?` (extra business fields, merged into
+`context`) and `messageOverride?` (each event has a stable default message —
+override only when a call site needs a more specific one); both are omitted from
+the per-event tables below.
+
+### Categories
+
+#### `authn` — authentication & session
+
+| Event               | Level    | Required fields                                                              |
+| ------------------- | -------- | ---------------------------------------------------------------------------- |
+| `loginSucceeded`    | `notice` | `userId`, `role`, `privileged` _(opt: `username`, `sessionId`)_              |
+| `loginFailed`       | `notice` | `username`, `reason`, `attemptCount`, `privileged` _(opt: `userId`, `role`)_ |
+| `sessionCreated`    | `notice` | `sessionId`                                                                  |
+| `sessionTerminated` | `notice` | `sessionId`, `reason`                                                        |
+| `sessionTimedOut`   | `notice` | `userId`, `sessionId`                                                        |
+| `tokenReused`       | `warn`   | `tokenId` _(opt: `sessionId`)_                                               |
+
+#### `userManagement` — user & permission management
+
+Acts on a **target** account (`targetUserId`, emitted as `context.target_user_id`)
+that is usually distinct from the **actor** (the request's scope `user_id`).
+Events log _what_ changed — field/role names and id references — never the values.
+
+| Event                | Level    | Required fields                        |
+| -------------------- | -------- | -------------------------------------- |
+| `accountCreated`     | `notice` | `targetUserId`                         |
+| `accountModified`    | `notice` | `targetUserId`, `changedFields`        |
+| `accountDeactivated` | `notice` | `targetUserId` _(opt: `reason`)_       |
+| `accountDeleted`     | `notice` | `targetUserId`                         |
+| `roleChanged`        | `notice` | `targetUserId`, `oldRoles`, `newRoles` |
+| `mfaSettingChanged`  | `notice` | `targetUserId`, `change`               |
+| `apiKeyChanged`      | `notice` | `targetUserId`, `keyId`, `action`      |
+| `passwordReset`      | `notice` | `targetUserId`, `initiatedBy`          |

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Swap pino's stdout destination for an in-memory capture so we assert on the
+// actual wire format (mirrors logger.test.ts).
+const h = vi.hoisted(() => ({ lines: [] as string[] }))
+
+vi.mock('pino', async importOriginal => {
+  const actual = await importOriginal<typeof import('pino')>()
+  const { Writable } = await import('node:stream')
+  const capture = new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      h.lines.push(chunk.toString())
+      cb()
+    },
+  })
+  return { ...actual, destination: () => capture }
+})
+
+import { createLogging } from '../index.js'
+
+const createBaseLogger = createLogging({ env: 'development', service: 'starter-kitty', version: '0.0.0' })
+
+function entries(): Record<string, unknown>[] {
+  return h.lines
+    .flatMap(line => line.split('\n'))
+    .filter(line => line.length > 0)
+    .map(line => JSON.parse(line) as Record<string, unknown>)
+}
+
+function at(index: number): Record<string, unknown> {
+  const entry = entries()[index]
+  if (!entry) throw new Error(`expected a log entry at index ${index}`)
+  return entry
+}
+
+beforeEach(() => {
+  h.lines = []
+})
+
+describe('audit.authn', () => {
+  it('stamps the Controlled audit fields and promotes userId to the user_id facet', () => {
+    createBaseLogger({ traceId: null, path: '/login', clientIp: '1.2.3.4', userAgent: 'jest' })
+      .scope({ action: 'verifyOtp' })
+      .audit.authn.loginSucceeded({
+        userId: 'u_1',
+        role: 'admin',
+        privileged: true,
+        username: 'jane',
+        sessionId: 's_1',
+      })
+
+    const line = at(0)
+    expect(line).toMatchObject({
+      level: 'NOTICE',
+      message: 'Login succeeded',
+      audit: true,
+      category: 'authn',
+      event: 'loginSucceeded',
+      action: 'verifyOtp',
+      user_id: 'u_1', // promoted to top level, not buried in context
+      client_ip: '1.2.3.4', // scope-read, present on the line
+      context: { role: 'admin', privileged: true, username: 'jane', session_id: 's_1' },
+    })
+    // The event name is distinct from `action` (the calling operation).
+    expect(line.event).not.toBe(line.action)
+  })
+
+  it('fires tokenReused at warn', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/api',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+      userId: 'u_1',
+    }).audit.authn.tokenReused({
+      tokenId: 't_1',
+    })
+
+    const line = at(0)
+    expect(line).toMatchObject({ level: 'WARN', event: 'tokenReused', audit: true, context: { token_id: 't_1' } })
+  })
+
+  it('emits a diagnostic when a required scope field is missing, then the event', () => {
+    // System logger has no clientIp / userAgent — both required by loginSucceeded.
+    createBaseLogger.system({ traceId: null, path: '/login' }).audit.authn.loginSucceeded({
+      userId: 'u_1',
+      role: 'admin',
+      privileged: false,
+    })
+
+    const lines = entries()
+    expect(lines).toHaveLength(2)
+    const [diagnostic, event] = lines
+    expect(diagnostic).toMatchObject({
+      level: 'WARN',
+      message: 'Audit event missing required scope field',
+      audit: true,
+      event: 'loginSucceeded',
+      context: { missing_scope: ['client_ip', 'user_agent'] },
+    })
+    expect(event).toMatchObject({ level: 'NOTICE', event: 'loginSucceeded' })
+  })
+
+  it('flags a payload/scope mismatch on a promoted field', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/login',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+      userId: 'u_scope',
+    }).audit.authn.loginSucceeded({ userId: 'u_payload', role: 'admin', privileged: false })
+
+    const mismatch = entries().find(l => l.message === 'Audit field mismatch: payload overrides scope')
+    expect(mismatch).toMatchObject({
+      level: 'WARN',
+      context: { field: 'user_id', scope_value: 'u_scope', payload_value: 'u_payload' },
+    })
+    // Payload wins on the emitted event.
+    const event = entries().find(l => l.event === 'loginSucceeded' && l.message === 'Login succeeded')
+    expect(event?.user_id).toBe('u_payload')
+  })
+
+  it('uses the scoped action and omits absent optional fields', () => {
+    createBaseLogger({ traceId: null, path: '/login', clientIp: '1.2.3.4', userAgent: 'jest' })
+      .scope({ action: 'authFlow' })
+      .audit.authn.loginFailed({ username: 'jane', reason: 'bad_password', attemptCount: 3, privileged: false })
+
+    const line = at(0)
+    expect(line).toMatchObject({
+      level: 'NOTICE',
+      event: 'loginFailed',
+      action: 'authFlow',
+      context: { username: 'jane', reason: 'bad_password', attempt_count: 3, privileged: false },
+    })
+    // userId/role were not supplied; they must not appear.
+    expect(line).not.toHaveProperty('user_id')
+    expect(line.context as Record<string, unknown>).not.toHaveProperty('role')
+  })
+
+  it('uses the per-event default message, overridable via messageOverride', () => {
+    const log = createBaseLogger({ traceId: null, path: '/login', clientIp: '1.2.3.4', userAgent: 'jest' })
+    log.audit.authn.loginFailed({ username: 'a', reason: 'bad_password', attemptCount: 1, privileged: false })
+    log.audit.authn.loginFailed({
+      username: 'b',
+      reason: 'bad_password',
+      attemptCount: 1,
+      privileged: false,
+      messageOverride: 'Repeated failure from same IP',
+    })
+
+    const lines = entries()
+    expect(lines[0]?.message).toBe('Login failed') // default
+    expect(lines[1]?.message).toBe('Repeated failure from same IP') // overridden
+  })
+})
+
+describe('audit.userManagement', () => {
+  it('separates actor (scope user_id) from target (context.target_user_id)', () => {
+    createBaseLogger({ traceId: null, path: '/admin/users', clientIp: '1.2.3.4', userAgent: 'jest', userId: 'admin_1' })
+      .scope({ action: 'updateRoles' })
+      .audit.userManagement.roleChanged({
+        targetUserId: 'u_2',
+        oldRoles: ['viewer'],
+        newRoles: ['editor', 'admin'],
+      })
+
+    const line = at(0)
+    expect(line).toMatchObject({
+      level: 'NOTICE',
+      audit: true,
+      category: 'userManagement',
+      event: 'roleChanged',
+      action: 'updateRoles',
+      user_id: 'admin_1', // the actor, top-level
+      context: {
+        target_user_id: 'u_2', // the target, in context — not a root facet
+        old_roles: ['viewer'],
+        new_roles: ['editor', 'admin'],
+      },
+    })
+    // The target is never promoted to a top-level facet.
+    expect(line).not.toHaveProperty('target_user_id')
+  })
+
+  it('logs changed field names, not values, on accountModified', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/admin/users',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+      userId: 'admin_1',
+    }).audit.userManagement.accountModified({ targetUserId: 'u_2', changedFields: ['email', 'phone'] })
+
+    const line = at(0)
+    expect(line.context).toMatchObject({ target_user_id: 'u_2', changed_fields: ['email', 'phone'] })
+  })
+
+  it('does not require an actor for self-service password reset', () => {
+    // No userId in scope (self-service) — only client_ip is required.
+    createBaseLogger({
+      traceId: null,
+      path: '/account/password',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+    }).audit.userManagement.passwordReset({ targetUserId: 'u_2', initiatedBy: 'self' })
+
+    const lines = entries()
+    // Only the event line — no "missing required scope" diagnostic for user_id.
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({
+      event: 'passwordReset',
+      context: { target_user_id: 'u_2', initiated_by: 'self' },
+    })
+  })
+
+  it('emits a diagnostic when an admin action lacks the actor in scope', () => {
+    // accountDeleted requires user_id (the admin actor) — absent here.
+    createBaseLogger({
+      traceId: null,
+      path: '/admin/users',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+    }).audit.userManagement.accountDeleted({
+      targetUserId: 'u_2',
+    })
+
+    const diagnostic = entries().find(l => l.message === 'Audit event missing required scope field')
+    expect(diagnostic).toMatchObject({ event: 'accountDeleted', context: { missing_scope: ['user_id'] } })
+  })
+})

--- a/packages/logging/src/audit/emit.ts
+++ b/packages/logging/src/audit/emit.ts
@@ -1,0 +1,84 @@
+import type { AuditLevel, EventSpec } from './spec.js'
+
+/**
+ * The base-logger capabilities the audit layer needs, injected by `LoggerImpl`
+ * so this module never touches pino directly (it layers *above* the base).
+ *
+ * @internal
+ */
+export interface AuditDeps {
+  /** The current scope bindings (snake_case wire keys) for scope-read asserts. */
+  bindings: () => Record<string, unknown>
+  /** Emit one line at the given audit level, with controlled fields + message. */
+  emit: (level: AuditLevel, fields: Record<string, unknown>, message: string) => void
+  /** The logger's current leaf action, read at call time. */
+  action: () => string | undefined
+}
+
+type AuditPayload = Record<string, unknown> & { context?: Record<string, unknown>; messageOverride?: string }
+
+/**
+ * Assemble and emit one audit line from an {@link EventSpec} and a call payload:
+ * promote canonical fields, read shared identity from scope (asserting required
+ * fields are present), and stamp the `audit`/`category`/`event` Controlled
+ * fields. Missing required scope, or a payload/scope mismatch on a promoted
+ * field, emits a loud diagnostic rather than failing silently (ADR-0007).
+ *
+ * @internal
+ */
+export const emitAudit = (deps: AuditDeps, spec: EventSpec, input: object): void => {
+  const payload = input as AuditPayload
+  const bindings = deps.bindings()
+
+  const action = deps.action()
+
+  const diagnostic = (message: string, context: Record<string, unknown>) =>
+    deps.emit('warn', { audit: true, category: spec.category, event: spec.event, action, context }, message)
+
+  // Scope-read assertion: required shared identity must be on the bound scope.
+  const missing = spec.requiredScope.filter(key => bindings[key] == null)
+  if (missing.length > 0) {
+    diagnostic('Audit event missing required scope field', { missing_scope: missing })
+  }
+
+  // Promote canonical payload fields to their top-level wire facet. Payload wins
+  // over scope; a real disagreement is surfaced rather than silently resolved.
+  const promoted: Record<string, unknown> = {}
+  for (const [payloadKey, wireKey] of Object.entries(spec.promote)) {
+    const value = payload[payloadKey]
+    if (value == null) continue
+    promoted[wireKey] = value
+    const bound = bindings[wireKey]
+    if (bound != null && bound !== value) {
+      diagnostic('Audit field mismatch: payload overrides scope', {
+        field: wireKey,
+        scope_value: bound,
+        payload_value: value,
+      })
+    }
+  }
+
+  // Event-specific fields land in context; free-form `context` merges on top.
+  const context: Record<string, unknown> = {}
+  for (const [payloadKey, wireKey] of Object.entries(spec.contextFields)) {
+    const value = payload[payloadKey]
+    if (value != null) context[wireKey] = value
+  }
+  if (payload.context) Object.assign(context, payload.context)
+
+  // The event's stable default message, overridable per call.
+  const message = payload.messageOverride ?? spec.message
+
+  deps.emit(
+    spec.level,
+    {
+      audit: true,
+      category: spec.category,
+      event: spec.event,
+      action,
+      ...promoted,
+      context: Object.keys(context).length > 0 ? context : undefined,
+    },
+    message,
+  )
+}

--- a/packages/logging/src/audit/index.ts
+++ b/packages/logging/src/audit/index.ts
@@ -1,0 +1,34 @@
+import type { AuditDeps } from './emit.js'
+import { emitAudit } from './emit.js'
+import { AUTHN_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
+import type { AuditLogger } from './types.js'
+
+export type { AuditDeps } from './emit.js'
+
+/**
+ * Build the `logger.audit` namespace over the injected base capabilities. Called
+ * lazily by `LoggerImpl`'s memoised `audit` getter — a request that emits no
+ * audit event never constructs it (ADR-0007).
+ *
+ * @internal
+ */
+export const createAuditLogger = (deps: AuditDeps): AuditLogger => ({
+  authn: {
+    loginSucceeded: input => emitAudit(deps, AUTHN_SPECS.loginSucceeded, input),
+    loginFailed: input => emitAudit(deps, AUTHN_SPECS.loginFailed, input),
+    sessionCreated: input => emitAudit(deps, AUTHN_SPECS.sessionCreated, input),
+    sessionTerminated: input => emitAudit(deps, AUTHN_SPECS.sessionTerminated, input),
+    sessionTimedOut: input => emitAudit(deps, AUTHN_SPECS.sessionTimedOut, input),
+    tokenReused: input => emitAudit(deps, AUTHN_SPECS.tokenReused, input),
+  },
+  userManagement: {
+    accountCreated: input => emitAudit(deps, USER_MANAGEMENT_SPECS.accountCreated, input),
+    accountModified: input => emitAudit(deps, USER_MANAGEMENT_SPECS.accountModified, input),
+    accountDeactivated: input => emitAudit(deps, USER_MANAGEMENT_SPECS.accountDeactivated, input),
+    accountDeleted: input => emitAudit(deps, USER_MANAGEMENT_SPECS.accountDeleted, input),
+    roleChanged: input => emitAudit(deps, USER_MANAGEMENT_SPECS.roleChanged, input),
+    mfaSettingChanged: input => emitAudit(deps, USER_MANAGEMENT_SPECS.mfaSettingChanged, input),
+    apiKeyChanged: input => emitAudit(deps, USER_MANAGEMENT_SPECS.apiKeyChanged, input),
+    passwordReset: input => emitAudit(deps, USER_MANAGEMENT_SPECS.passwordReset, input),
+  },
+})

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -1,0 +1,163 @@
+/**
+ * The runtime spec table that drives audit emission. Each {@link EventSpec} is
+ * the single source of truth for one event's category, level, which payload
+ * fields are promoted to a canonical wire facet, which scope fields must be
+ * present (runtime-asserted), and which payload fields land in `context`.
+ *
+ * The typed input interfaces in `./types.ts` are the compile-time mirror of
+ * these specs; keep the two in sync. There is no "sensitive fields" entry — the
+ * helper does not transform values (ADR-0007).
+ *
+ * @internal
+ */
+
+/** Severity an audit event may fire at. Bounded to `{ notice, warn }` (ADR-0007). */
+export type AuditLevel = 'notice' | 'warn'
+
+export interface EventSpec {
+  /** Closed-taxonomy group, stamped as the `category` wire field. */
+  category: string
+  /** The specific event, stamped as the `event` wire field. */
+  event: string
+  /** Fixed severity for this event. */
+  level: AuditLevel
+  /** Stable, low-cardinality human message. */
+  message: string
+  /** payload key to its canonical wire field (promoted to top level; payload wins). */
+  promote: Record<string, string>
+  /** Scope (child-binding) keys that must be present; missing ones emit a diagnostic. */
+  requiredScope: string[]
+  /** payload key to its `context` wire key (snake_case). */
+  contextFields: Record<string, string>
+}
+
+const authn = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'authn',
+  event,
+  ...spec,
+})
+
+/** Authentication & session event specs. */
+export const AUTHN_SPECS = {
+  loginSucceeded: authn('loginSucceeded', {
+    level: 'notice',
+    message: 'Login succeeded',
+    promote: { userId: 'user_id' },
+    // user_agent is the device/browser signal (ADR-0007); client_ip the source.
+    requiredScope: ['client_ip', 'user_agent'],
+    contextFields: { role: 'role', privileged: 'privileged', username: 'username', sessionId: 'session_id' },
+  }),
+  loginFailed: authn('loginFailed', {
+    level: 'notice',
+    message: 'Login failed',
+    promote: { userId: 'user_id' },
+    requiredScope: ['client_ip'],
+    contextFields: {
+      username: 'username',
+      reason: 'reason',
+      attemptCount: 'attempt_count',
+      privileged: 'privileged',
+      role: 'role',
+    },
+  }),
+  sessionCreated: authn('sessionCreated', {
+    level: 'notice',
+    message: 'Session created',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { sessionId: 'session_id' },
+  }),
+  sessionTerminated: authn('sessionTerminated', {
+    level: 'notice',
+    message: 'Session terminated',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { sessionId: 'session_id', reason: 'reason' },
+  }),
+  sessionTimedOut: authn('sessionTimedOut', {
+    level: 'notice',
+    message: 'Session timed out',
+    promote: { userId: 'user_id' },
+    // A timeout sweep may run with no request scope, so identity is payload-borne.
+    requiredScope: ['client_ip'],
+    contextFields: { sessionId: 'session_id' },
+  }),
+  tokenReused: authn('tokenReused', {
+    level: 'warn',
+    message: 'Session token reused',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { tokenId: 'token_id', sessionId: 'session_id' },
+  }),
+} satisfies Record<string, EventSpec>
+
+const userMgmt = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'userManagement',
+  event,
+  ...spec,
+})
+
+// The actor is the request's bound `user_id` (scope-read); the target account is
+// `targetUserId` in the payload, emitted as `context.target_user_id` — event
+// data, never promoted to a root facet. `accountCreated` / `passwordReset` do not
+// require `user_id` in scope: they may be self-service (self-signup, self reset),
+// which has no admin actor.
+/** User & permission management event specs. */
+export const USER_MANAGEMENT_SPECS = {
+  accountCreated: userMgmt('accountCreated', {
+    level: 'notice',
+    message: 'Account created',
+    promote: {},
+    requiredScope: ['client_ip'],
+    contextFields: { targetUserId: 'target_user_id' },
+  }),
+  accountModified: userMgmt('accountModified', {
+    level: 'notice',
+    message: 'Account modified',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { targetUserId: 'target_user_id', changedFields: 'changed_fields' },
+  }),
+  accountDeactivated: userMgmt('accountDeactivated', {
+    level: 'notice',
+    message: 'Account deactivated',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { targetUserId: 'target_user_id', reason: 'reason' },
+  }),
+  accountDeleted: userMgmt('accountDeleted', {
+    level: 'notice',
+    message: 'Account deleted',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { targetUserId: 'target_user_id' },
+  }),
+  roleChanged: userMgmt('roleChanged', {
+    level: 'notice',
+    message: 'Role changed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { targetUserId: 'target_user_id', oldRoles: 'old_roles', newRoles: 'new_roles' },
+  }),
+  mfaSettingChanged: userMgmt('mfaSettingChanged', {
+    level: 'notice',
+    message: 'MFA setting changed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { targetUserId: 'target_user_id', change: 'change' },
+  }),
+  apiKeyChanged: userMgmt('apiKeyChanged', {
+    level: 'notice',
+    message: 'API key changed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { targetUserId: 'target_user_id', keyId: 'key_id', action: 'action' },
+  }),
+  passwordReset: userMgmt('passwordReset', {
+    level: 'notice',
+    message: 'Password reset',
+    promote: {},
+    requiredScope: ['client_ip'],
+    contextFields: { targetUserId: 'target_user_id', initiatedBy: 'initiated_by' },
+  }),
+} satisfies Record<string, EventSpec>

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -1,0 +1,222 @@
+/**
+ * The fixed-shape **audit** helper layer — `logger.audit.<category>.<event>(…)`.
+ *
+ * Each method records one auditable business event from a closed, governed
+ * taxonomy (ADR-0007). Unlike the free-form base logger, every event has a
+ * *fixed, type-enforced shape*: required fields are mandatory at compile time,
+ * shared identity is read from the bound scope, and the helper stamps the
+ * Controlled wire fields `audit`, `category`, and `event`.
+ *
+ * The helper performs **no value transformation**: secrets are kept out *by
+ * shape* (they are never fields) and PII is left to the sink. See ADR-0007.
+ *
+ * @public
+ */
+export interface AuditLogger {
+  /** Authentication & session events. */
+  authn: AuthnAudit
+  /** User & permission management events. */
+  userManagement: UserManagementAudit
+}
+
+/**
+ * Authentication & session audit events (category `authn`).
+ *
+ * @public
+ */
+export interface AuthnAudit {
+  /** A successful interactive login. Fires at `notice`. */
+  loginSucceeded(input: LoginSucceededInput): void
+  /** A failed login attempt. Fires at `notice`. */
+  loginFailed(input: LoginFailedInput): void
+  /** A session was created (e.g. cookie sealed at login). Fires at `notice`. */
+  sessionCreated(input: SessionCreatedInput): void
+  /** A session was explicitly ended (logout / destroy). Fires at `notice`. */
+  sessionTerminated(input: SessionTerminatedInput): void
+  /** A session expired by inactivity/TTL. Fires at `notice`. */
+  sessionTimedOut(input: SessionTimedOutInput): void
+  /** A session/auth token was replayed — a theft signal. Fires at `warn`. */
+  tokenReused(input: TokenReusedInput): void
+}
+
+/**
+ * Free-form business fields an audit call may carry in addition to its fixed
+ * shape. Merged into the line's `context`. App-owned; keep keys `snake_case`.
+ *
+ * @public
+ */
+export type AuditContext = Record<string, unknown>
+
+/**
+ * Fields every audit input accepts in addition to its event-specific shape.
+ *
+ * @public
+ */
+export interface AuditInputBase {
+  /**
+   * Override the event's **stable default** message (e.g. `loginSucceeded`
+   * defaults to `"Login succeeded"`). Omit to use that default — the key is named
+   * `messageOverride` precisely to signal a default already exists. Prefer the
+   * default unless a call site genuinely needs a more specific human message;
+   * grouping/filtering keys off `event`/`category`, not the message.
+   */
+  messageOverride?: string
+  /** Optional free-form business fields, merged into the `context` field. */
+  context?: AuditContext
+}
+
+/** Input for {@link AuthnAudit.loginSucceeded}. @public */
+export interface LoginSucceededInput extends AuditInputBase {
+  /** The authenticated user. Promoted to the canonical `user_id` facet. */
+  userId: string
+  /** The user's role at login. */
+  role: string
+  /** Whether this is a privileged account login (flagged in the matrix). */
+  privileged: boolean
+  /** The login handle (may differ from `userId`). Optional. */
+  username?: string
+  /** Session identifier, if a session was created. Absent for stateless auth. */
+  sessionId?: string
+}
+
+/** Input for {@link AuthnAudit.loginFailed}. @public */
+export interface LoginFailedInput extends AuditInputBase {
+  /** The attempted login handle — the only identity known on a failed attempt. */
+  username: string
+  /** Low-cardinality failure reason, e.g. `bad_password`, `unknown_user`. */
+  reason: string
+  /** Number of attempts in the current window. */
+  attemptCount: number
+  /** Whether a privileged account was targeted. */
+  privileged: boolean
+  /** The resolved user, if the account was known. Promoted to `user_id`. */
+  userId?: string
+  /** The user's role, if known. */
+  role?: string
+}
+
+/** Input for {@link AuthnAudit.sessionCreated}. @public */
+export interface SessionCreatedInput extends AuditInputBase {
+  /** Session identifier (a non-impersonatable reference, not the bearer token). */
+  sessionId: string
+}
+
+/** Input for {@link AuthnAudit.sessionTerminated}. @public */
+export interface SessionTerminatedInput extends AuditInputBase {
+  /** The session being ended (a reference, not the bearer token). */
+  sessionId: string
+  /** Why the session ended, e.g. `logout`, `revoked`. */
+  reason: string
+}
+
+/** Input for {@link AuthnAudit.sessionTimedOut}. @public */
+export interface SessionTimedOutInput extends AuditInputBase {
+  /** The session owner. Promoted to `user_id` (a timeout sweep has no scope). */
+  userId: string
+  /** The timed-out session (a reference, not the bearer token). */
+  sessionId: string
+}
+
+/** Input for {@link AuthnAudit.tokenReused}. @public */
+export interface TokenReusedInput extends AuditInputBase {
+  /** The reused token's identifier (a reference, not the token value). */
+  tokenId: string
+  /** The session the token belonged to, if any. */
+  sessionId?: string
+}
+
+/**
+ * User & permission management audit events (category `userManagement`).
+ *
+ * These act on a *target* account that is usually distinct from the *actor*: the
+ * actor is the authenticated request's `user_id` (read from scope), the target
+ * is `targetUserId` in the payload (emitted as `context.target_user_id`). They
+ * coincide only for self-service actions (self-signup, self password reset).
+ *
+ * Events log *what changed*, never the changed values — field/role names and
+ * id references only — so secrets and PII stay unrepresentable.
+ *
+ * @public
+ */
+export interface UserManagementAudit {
+  /** An account was created (admin-created or self-signup). Fires at `notice`. */
+  accountCreated(input: AccountCreatedInput): void
+  /** An account's attributes were changed. Fires at `notice`. */
+  accountModified(input: AccountModifiedInput): void
+  /** An account was deactivated/suspended. Fires at `notice`. */
+  accountDeactivated(input: AccountDeactivatedInput): void
+  /** An account was deleted. Fires at `notice`. */
+  accountDeleted(input: AccountDeletedInput): void
+  /** An account's roles/permissions changed. Fires at `notice`. */
+  roleChanged(input: RoleChangedInput): void
+  /** An account's MFA settings changed. Fires at `notice`. */
+  mfaSettingChanged(input: MfaSettingChangedInput): void
+  /** An account's API key was created, rotated, or revoked. Fires at `notice`. */
+  apiKeyChanged(input: ApiKeyChangedInput): void
+  /** An account's password was reset (self-service or admin). Fires at `notice`. */
+  passwordReset(input: PasswordResetInput): void
+}
+
+/** Input for {@link UserManagementAudit.accountCreated}. @public */
+export interface AccountCreatedInput extends AuditInputBase {
+  /** The account created. Emitted as `context.target_user_id`. */
+  targetUserId: string
+}
+
+/** Input for {@link UserManagementAudit.accountModified}. @public */
+export interface AccountModifiedInput extends AuditInputBase {
+  /** The account modified. Emitted as `context.target_user_id`. */
+  targetUserId: string
+  /** The names of the fields that changed — never their values. */
+  changedFields: string[]
+}
+
+/** Input for {@link UserManagementAudit.accountDeactivated}. @public */
+export interface AccountDeactivatedInput extends AuditInputBase {
+  /** The account deactivated. Emitted as `context.target_user_id`. */
+  targetUserId: string
+  /** Why the account was deactivated, e.g. `admin_action`, `inactivity`. */
+  reason?: string
+}
+
+/** Input for {@link UserManagementAudit.accountDeleted}. @public */
+export interface AccountDeletedInput extends AuditInputBase {
+  /** The account deleted. Emitted as `context.target_user_id`. */
+  targetUserId: string
+}
+
+/** Input for {@link UserManagementAudit.roleChanged}. @public */
+export interface RoleChangedInput extends AuditInputBase {
+  /** The account whose roles changed. Emitted as `context.target_user_id`. */
+  targetUserId: string
+  /** The role/permission names before the change. */
+  oldRoles: string[]
+  /** The role/permission names after the change. */
+  newRoles: string[]
+}
+
+/** Input for {@link UserManagementAudit.mfaSettingChanged}. @public */
+export interface MfaSettingChangedInput extends AuditInputBase {
+  /** The account whose MFA settings changed. Emitted as `context.target_user_id`. */
+  targetUserId: string
+  /** What changed, e.g. `enabled`, `disabled`, `reset`, `method_added`. */
+  change: string
+}
+
+/** Input for {@link UserManagementAudit.apiKeyChanged}. @public */
+export interface ApiKeyChangedInput extends AuditInputBase {
+  /** The account that owns the key. Emitted as `context.target_user_id`. */
+  targetUserId: string
+  /** The key's identifier — a reference, never the key value. */
+  keyId: string
+  /** The lifecycle action performed on the key. */
+  action: 'created' | 'rotated' | 'revoked'
+}
+
+/** Input for {@link UserManagementAudit.passwordReset}. @public */
+export interface PasswordResetInput extends AuditInputBase {
+  /** The account whose password was reset. Emitted as `context.target_user_id`. */
+  targetUserId: string
+  /** Who initiated the reset — the account holder, or an administrator. */
+  initiatedBy: 'self' | 'admin'
+}

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -12,6 +12,7 @@
  * @packageDocumentation
  */
 
+export type * from './audit/types.js'
 export { serializeError } from './error.js'
 export * from './logger.js'
 export * from './types.js'

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -2,6 +2,8 @@ import type { DestinationStream } from 'pino'
 import { destination, pino } from 'pino'
 import { PinoPretty } from 'pino-pretty'
 
+import { createAuditLogger } from './audit/index.js'
+import type { AuditLogger } from './audit/types.js'
 import { serializeContext } from './context.js'
 import { getCauseFromUnknown, serializeError } from './error.js'
 import type { Logger, LogInput } from './types.js'
@@ -249,6 +251,8 @@ class LoggerImpl implements Logger {
   private context: NonNullable<LogInput['context']> | null
   /** The most-specific action in scope (the leaf). Per-call `action` still wins. */
   private action: string | null
+  /** Lazily-built, memoised `audit` namespace; see the `audit` getter. */
+  private _audit?: AuditLogger
 
   constructor(
     logger: ReturnType<typeof bindChild>,
@@ -286,6 +290,21 @@ class LoggerImpl implements Logger {
   setContext(options: { context: LogInput['context'] }) {
     this.context = mergeContext(this.context, options.context)
     return this
+  }
+
+  /**
+   * The audit helper namespace. Built on first access and memoised, so a logger
+   * that emits no audit event pays nothing (ADR-0007). The injected callbacks
+   * read scope and action *at call time*, so they track `setAction` mutations.
+   */
+  get audit(): AuditLogger {
+    return (this._audit ??= createAuditLogger({
+      bindings: () => this.logger.bindings(),
+      emit: (level, fields, message) => {
+        this.logger[level](fields, message)
+      },
+      action: () => this.action ?? undefined,
+    }))
   }
 
   debug(input: Omit<LogInput, 'error'>) {

--- a/packages/logging/src/types.ts
+++ b/packages/logging/src/types.ts
@@ -1,3 +1,5 @@
+import type { AuditLogger } from './audit/types.js'
+
 /**
  * The shape of a single log call: a `message`, an optional `action` naming the
  * operation, and optional structured `context`, `error`, and `merged` fields.
@@ -127,6 +129,13 @@ export interface Logger {
    * page-worthy). Carries the `error` that caused the failure.
    */
   error(input: LogInput): void
+
+  /**
+   * The fixed-shape **audit** helpers — `audit.<category>.<event>(…)` — for
+   * recording compliance-auditable events with a type-enforced shape. Server
+   * side only; absent from {@link BasicLogger}. See {@link AuditLogger}.
+   */
+  readonly audit: AuditLogger
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the **fixed-shape audit helper layer** — `logger.audit.<category>.<event>(…)` — the realization of the "fixed-shape helper loggers" anticipated in ADR-0003 / ADR-0005. Each method records one compliance-auditable event with a **type-enforced shape**, layered above the base logger. Recorded as [ADR-0006](docs/adr/0006-fixed-shape-audit-helpers.md).

```ts
logger.scope({ action: 'verifyOtp' }).audit.authn.loginSucceeded({
  userId: 'u_1', role: 'admin', privileged: true,
})
// => { "level":"NOTICE", "audit":true, "category":"authn", "event":"loginSucceeded",
//      "action":"verifyOtp", "user_id":"u_1", "client_ip":"…",
//      "context": { "role":"admin", "privileged":true } }
```

## Categories

- **`authn`** — `loginSucceeded`, `loginFailed`, `sessionCreated`, `sessionTerminated`, `sessionTimedOut`, `tokenReused`.
- **`userManagement`** — `accountCreated`/`Modified`/`Deactivated`/`Deleted`, `roleChanged`, `mfaSettingChanged`, `apiKeyChanged`, `passwordReset`.

Remaining categories (`dataAccess`, `configChange`, `apiUsage`, `failures`) are follow-ups against the same pattern.

## Design highlights (see ADR-0006)

- **Closed, governed taxonomy** — a curated compliance set, not a convenience grab-bag. The category list lives in code; the ADR records the durable principles only.
- **Per-event field sourcing** — identity is payload-required for events *upstream* of authentication (a login *produces* `user_id`) and **scope-read** for downstream events. Client identity (`client_ip`/`user_agent`) is now *guaranteed at construction* by the base request shape, so its scope-read assertion is a compile-time guarantee for request loggers; a loud runtime diagnostic remains the backstop (missing required scope, or a `.system()` logger emitting an interactive-auth event).
- **Actor vs. target** — `userManagement` separates the acting `user_id` (scope) from the affected `context.target_user_id` (payload). Event-specific data always lives in `context`, never a root facet.
- **Per-event level** — bounded to `{ notice, warn }`; security-relevant denials/failures (e.g. `tokenReused`) fire at `warn`.
- **No value transformation** — secrets are *unrepresentable* (never fields; e.g. you log a `key_id`, never the key) and PII is a sink concern. Events log *what changed* (`changed_fields`, `old_roles`/`new_roles`), not the values.
- **`.audit` is on `Logger` only** (not `BasicLogger` — audit is server-side), attached via a lazy, memoised getter so requests that emit no audit event pay nothing.

## Wire schema

Three new **conditional Controlled** fields, present only on audit lines: `audit` (boolean marker the sink routes WORM/immutable storage on), `category`, and `event` (distinct from `action`, which stays the calling operation — a single leaf, no `history`).

## Testing

- `packages/logging/src/__tests__/audit.test.ts` — field stamping, canonical promotion, scope-read diagnostics, payload/scope mismatch, level mapping, actor/target separation.
- Full suite green; API report regenerated and `ci:report` clean; lint clean; all public members documented.

## Stack

Based on `feat/add-logging-package` (Graphite stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
