### PR TITLE
feat(logging): add the dataAccess audit category

### DIFF
--- a/.changeset/audit-data-access.md
+++ b/.changeset/audit-data-access.md
@@ -1,0 +1,10 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add the `dataAccess` audit category — `logger.audit.dataAccess.*`:
+`dataAccessed`, `recordDownloaded`, and `bulkExported`. Downstream events — the
+actor (`user_id`) and `client_ip` are read from scope. They log *what* was
+accessed (resource type/id, classification, size, export destination/filters),
+never the data itself; the data "action taken" is named `accessType` to avoid
+clashing with the Controlled `action` field.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -45,6 +45,7 @@ export interface AuditInputBase {
 // @public
 export interface AuditLogger {
     authn: AuthnAudit;
+    dataAccess: DataAccessAudit;
     userManagement: UserManagementAudit;
 }
 
@@ -67,6 +68,14 @@ export interface BasicLogger<Input extends Partial<LogInput> = LogInput> {
 }
 
 // @public
+export interface BulkExportedInput extends AuditInputBase {
+    classification: string;
+    destination: string;
+    filters?: AuditContext;
+    recordCount: number;
+}
+
+// @public
 export interface CreateLogger {
     (options: LoggerOptions): Logger;
     system(options: SystemLoggerOptions): Logger;
@@ -74,6 +83,21 @@ export interface CreateLogger {
 
 // @public
 export const createLogging: (config: LoggingConfig) => CreateLogger;
+
+// @public
+export interface DataAccessAudit {
+    bulkExported(input: BulkExportedInput): void;
+    dataAccessed(input: DataAccessedInput): void;
+    recordDownloaded(input: RecordDownloadedInput): void;
+}
+
+// @public
+export interface DataAccessedInput extends AuditInputBase {
+    accessType: string;
+    classification: string;
+    resourceId: string;
+    resourceType: string;
+}
 
 // @public
 export interface Logger {
@@ -160,6 +184,16 @@ export interface MfaSettingChangedInput extends AuditInputBase {
 export interface PasswordResetInput extends AuditInputBase {
     initiatedBy: 'self' | 'admin';
     targetUserId: string;
+}
+
+// @public
+export interface RecordDownloadedInput extends AuditInputBase {
+    classification: string;
+    method: string;
+    resourceId: string;
+    resourceType?: string;
+    role?: string;
+    sizeBytes: number;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -307,3 +307,15 @@ Events log _what_ changed — field/role names and id references — never the v
 | `mfaSettingChanged`  | `notice` | `targetUserId`, `change`               |
 | `apiKeyChanged`      | `notice` | `targetUserId`, `keyId`, `action`      |
 | `passwordReset`      | `notice` | `targetUserId`, `initiatedBy`          |
+
+#### `dataAccess` — data access, movement & export
+
+Downstream of authentication: the acting `user_id` and `client_ip` are
+scope-read. Log _what_ was accessed — resource type/id, classification — never
+the data itself.
+
+| Event              | Level    | Required fields                                                                       |
+| ------------------ | -------- | ------------------------------------------------------------------------------------- |
+| `dataAccessed`     | `notice` | `resourceType`, `resourceId`, `accessType`, `classification`                          |
+| `recordDownloaded` | `notice` | `resourceId`, `classification`, `sizeBytes`, `method` _(opt: `resourceType`, `role`)_ |
+| `bulkExported`     | `notice` | `destination`, `classification`, `recordCount` _(opt: `filters`)_                     |

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -228,3 +228,53 @@ describe('audit.userManagement', () => {
     expect(diagnostic).toMatchObject({ event: 'accountDeleted', context: { missing_scope: ['user_id'] } })
   })
 })
+
+describe('audit.dataAccess', () => {
+  const reqLogger = () =>
+    createBaseLogger({ traceId: null, path: '/data', clientIp: '1.2.3.4', userAgent: 'jest', userId: 'u_1' })
+
+  it('records a data access with resource and classification in context', () => {
+    reqLogger().audit.dataAccess.dataAccessed({
+      resourceType: 'citizen_record',
+      resourceId: 'r_1',
+      accessType: 'read',
+      classification: 'confidential',
+    })
+    const line = at(0)
+    expect(line).toMatchObject({
+      audit: true,
+      category: 'dataAccess',
+      event: 'dataAccessed',
+      user_id: 'u_1',
+      context: {
+        resource_type: 'citizen_record',
+        resource_id: 'r_1',
+        access_type: 'read',
+        classification: 'confidential',
+      },
+    })
+  })
+
+  it('records a bulk export with filters nested in context', () => {
+    reqLogger().audit.dataAccess.bulkExported({
+      destination: 's3://exports',
+      classification: 'restricted',
+      recordCount: 1200,
+      filters: { status: 'active', region: 'sg' },
+    })
+    expect(at(0).context).toMatchObject({
+      destination: 's3://exports',
+      classification: 'restricted',
+      record_count: 1200,
+      filters: { status: 'active', region: 'sg' },
+    })
+  })
+
+  it('emits a diagnostic when the actor is missing from scope', () => {
+    createBaseLogger
+      .system({ traceId: null, path: '/job' })
+      .audit.dataAccess.dataAccessed({ resourceType: 't', resourceId: 'r', accessType: 'read', classification: 'pii' })
+    const diagnostic = entries().find(l => l.message === 'Audit event missing required scope field')
+    expect(diagnostic).toMatchObject({ event: 'dataAccessed', context: { missing_scope: ['user_id', 'client_ip'] } })
+  })
+})

--- a/packages/logging/src/audit/index.ts
+++ b/packages/logging/src/audit/index.ts
@@ -1,6 +1,6 @@
 import type { AuditDeps } from './emit.js'
 import { emitAudit } from './emit.js'
-import { AUTHN_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
+import { AUTHN_SPECS, DATA_ACCESS_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
 import type { AuditLogger } from './types.js'
 
 export type { AuditDeps } from './emit.js'
@@ -30,5 +30,10 @@ export const createAuditLogger = (deps: AuditDeps): AuditLogger => ({
     mfaSettingChanged: input => emitAudit(deps, USER_MANAGEMENT_SPECS.mfaSettingChanged, input),
     apiKeyChanged: input => emitAudit(deps, USER_MANAGEMENT_SPECS.apiKeyChanged, input),
     passwordReset: input => emitAudit(deps, USER_MANAGEMENT_SPECS.passwordReset, input),
+  },
+  dataAccess: {
+    dataAccessed: input => emitAudit(deps, DATA_ACCESS_SPECS.dataAccessed, input),
+    recordDownloaded: input => emitAudit(deps, DATA_ACCESS_SPECS.recordDownloaded, input),
+    bulkExported: input => emitAudit(deps, DATA_ACCESS_SPECS.bulkExported, input),
   },
 })

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -161,3 +161,53 @@ export const USER_MANAGEMENT_SPECS = {
     contextFields: { targetUserId: 'target_user_id', initiatedBy: 'initiated_by' },
   }),
 } satisfies Record<string, EventSpec>
+
+const dataAccess = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'dataAccess',
+  event,
+  ...spec,
+})
+
+// Downstream of auth: actor (`user_id`) and `client_ip` are scope-read. Events
+// log what was accessed (resource type/id, classification), never the data.
+/** Data access, movement & export event specs. */
+export const DATA_ACCESS_SPECS = {
+  dataAccessed: dataAccess('dataAccessed', {
+    level: 'notice',
+    message: 'Data accessed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: {
+      resourceType: 'resource_type',
+      resourceId: 'resource_id',
+      accessType: 'access_type',
+      classification: 'classification',
+    },
+  }),
+  recordDownloaded: dataAccess('recordDownloaded', {
+    level: 'notice',
+    message: 'Record downloaded',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: {
+      resourceId: 'resource_id',
+      classification: 'classification',
+      sizeBytes: 'size_bytes',
+      method: 'method',
+      resourceType: 'resource_type',
+      role: 'role',
+    },
+  }),
+  bulkExported: dataAccess('bulkExported', {
+    level: 'notice',
+    message: 'Bulk data exported',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: {
+      destination: 'destination',
+      classification: 'classification',
+      recordCount: 'record_count',
+      filters: 'filters',
+    },
+  }),
+} satisfies Record<string, EventSpec>

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -17,6 +17,8 @@ export interface AuditLogger {
   authn: AuthnAudit
   /** User & permission management events. */
   userManagement: UserManagementAudit
+  /** Data access, movement & export events. */
+  dataAccess: DataAccessAudit
 }
 
 /**
@@ -219,4 +221,62 @@ export interface PasswordResetInput extends AuditInputBase {
   targetUserId: string
   /** Who initiated the reset — the account holder, or an administrator. */
   initiatedBy: 'self' | 'admin'
+}
+
+/**
+ * Data access, movement & export audit events (category `dataAccess`).
+ *
+ * Downstream of authentication: the acting `user_id` and `client_ip` are
+ * scope-read. Log *what* was accessed — resource type/id, classification — never
+ * the data itself.
+ *
+ * @public
+ */
+export interface DataAccessAudit {
+  /** PII/confidential data was accessed. Fires at `notice`. */
+  dataAccessed(input: DataAccessedInput): void
+  /** A file/record was downloaded. Fires at `notice`. */
+  recordDownloaded(input: RecordDownloadedInput): void
+  /** A bulk data export was performed. Fires at `notice`. */
+  bulkExported(input: BulkExportedInput): void
+}
+
+/** Input for {@link DataAccessAudit.dataAccessed}. @public */
+export interface DataAccessedInput extends AuditInputBase {
+  /** The kind of resource accessed, e.g. `citizen_record`. */
+  resourceType: string
+  /** The accessed resource's identifier. */
+  resourceId: string
+  /** What was done with the data, e.g. `read`, `view`, `query` — distinct from the top-level `action`. */
+  accessType: string
+  /** The data's classification, e.g. `confidential`, `restricted`, `pii`. */
+  classification: string
+}
+
+/** Input for {@link DataAccessAudit.recordDownloaded}. @public */
+export interface RecordDownloadedInput extends AuditInputBase {
+  /** The downloaded resource's identifier. */
+  resourceId: string
+  /** The data's classification. */
+  classification: string
+  /** Size of the download in bytes. */
+  sizeBytes: number
+  /** How it was downloaded, e.g. `csv`, `pdf`, `api`. */
+  method: string
+  /** The kind of resource, if useful. */
+  resourceType?: string
+  /** The acting user's role, if known. */
+  role?: string
+}
+
+/** Input for {@link DataAccessAudit.bulkExported}. @public */
+export interface BulkExportedInput extends AuditInputBase {
+  /** Where the export was sent, e.g. an email, bucket, or download channel. */
+  destination: string
+  /** The data's classification. */
+  classification: string
+  /** How many records were exported. */
+  recordCount: number
+  /** The filters/parameters that scoped the export. */
+  filters?: AuditContext
 }


### PR DESCRIPTION
## Summary

Adds the **`dataAccess`** audit category — `logger.audit.dataAccess.*` (ADR-0006), the third category in the fixed-shape audit layer.

## Events (all `notice`)

- **`dataAccessed`** — access to PII/confidential data (resource type/id, access type, classification).
- **`recordDownloaded`** — a file/record download (id, classification, size, method, optional role/type).
- **`bulkExported`** — a bulk export (destination, classification, record count, optional filters).

## Design

- **Downstream events** — the actor (`user_id`) and `client_ip` are **scope-read** (runtime-asserted, loud diagnostic if missing).
- Logs **what** was accessed — resource type/id, classification, size, export destination/filters — **never the data itself**.
- The data "action taken" is named **`accessType`** to avoid clashing with the Controlled `action` field.

## Tests & changeset

3 new tests (shape, nested export filters, missing-actor diagnostic); a `.changeset/audit-data-access.md` entry. Full suite green; API report regenerated; lint/ci:report clean.

## Stack

Part of the audit-helper Graphite stack, based on **#61** (audit helpers). Targets the `userManagement`/`authn` helper layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
