### PR TITLE
feat(logging): add the configChange audit category

### DIFF
--- a/.changeset/audit-config-change.md
+++ b/.changeset/audit-config-change.md
@@ -1,0 +1,9 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add the `configChange` audit category — `logger.audit.configChange.*`:
+`securityConfigChanged` and `policyChanged` (the org-level policy changes —
+ACLs, retention, logging, password/access policy — deferred from
+`userManagement`). Admin actions: the actor (`user_id`) and `client_ip` are
+read from scope; events log the setting/policy and non-sensitive old/new values.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -45,6 +45,7 @@ export interface AuditInputBase {
 // @public
 export interface AuditLogger {
     authn: AuthnAudit;
+    configChange: ConfigChangeAudit;
     dataAccess: DataAccessAudit;
     userManagement: UserManagementAudit;
 }
@@ -73,6 +74,12 @@ export interface BulkExportedInput extends AuditInputBase {
     destination: string;
     filters?: AuditContext;
     recordCount: number;
+}
+
+// @public
+export interface ConfigChangeAudit {
+    policyChanged(input: PolicyChangedInput): void;
+    securityConfigChanged(input: SecurityConfigChangedInput): void;
 }
 
 // @public
@@ -187,6 +194,14 @@ export interface PasswordResetInput extends AuditInputBase {
 }
 
 // @public
+export interface PolicyChangedInput extends AuditInputBase {
+    newValue?: unknown;
+    oldValue?: unknown;
+    policyType: string;
+    summary?: string;
+}
+
+// @public
 export interface RecordDownloadedInput extends AuditInputBase {
     classification: string;
     method: string;
@@ -201,6 +216,13 @@ export interface RoleChangedInput extends AuditInputBase {
     newRoles: string[];
     oldRoles: string[];
     targetUserId: string;
+}
+
+// @public
+export interface SecurityConfigChangedInput extends AuditInputBase {
+    newValue?: unknown;
+    oldValue?: unknown;
+    setting: string;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -319,3 +319,14 @@ the data itself.
 | `dataAccessed`     | `notice` | `resourceType`, `resourceId`, `accessType`, `classification`                          |
 | `recordDownloaded` | `notice` | `resourceId`, `classification`, `sizeBytes`, `method` _(opt: `resourceType`, `role`)_ |
 | `bulkExported`     | `notice` | `destination`, `classification`, `recordCount` _(opt: `filters`)_                     |
+
+#### `configChange` — application & security-configuration changes
+
+Admin actions, downstream of auth: actor `user_id` and `client_ip` are
+scope-read. Log _what_ changed (and old/new values when non-sensitive), never
+secrets.
+
+| Event                   | Level    | Required fields                                         |
+| ----------------------- | -------- | ------------------------------------------------------- |
+| `securityConfigChanged` | `notice` | `setting` _(opt: `oldValue`, `newValue`)_               |
+| `policyChanged`         | `notice` | `policyType` _(opt: `summary`, `oldValue`, `newValue`)_ |

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -278,3 +278,37 @@ describe('audit.dataAccess', () => {
     expect(diagnostic).toMatchObject({ event: 'dataAccessed', context: { missing_scope: ['user_id', 'client_ip'] } })
   })
 })
+
+describe('audit.configChange', () => {
+  const reqLogger = () =>
+    createBaseLogger({
+      traceId: null,
+      path: '/admin/settings',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+      userId: 'admin_1',
+    })
+
+  it('records a security config change with old/new values in context', () => {
+    reqLogger().audit.configChange.securityConfigChanged({
+      setting: 'session_timeout',
+      oldValue: 30,
+      newValue: 15,
+    })
+    const line = at(0)
+    expect(line).toMatchObject({
+      audit: true,
+      category: 'configChange',
+      event: 'securityConfigChanged',
+      user_id: 'admin_1',
+      context: { setting: 'session_timeout', old_value: 30, new_value: 15 },
+    })
+  })
+
+  it('records a policy change and omits absent optional values', () => {
+    reqLogger().audit.configChange.policyChanged({ policyType: 'retention', summary: '30d -> 90d' })
+    const line = at(0)
+    expect(line.context).toMatchObject({ policy_type: 'retention', summary: '30d -> 90d' })
+    expect(line.context as Record<string, unknown>).not.toHaveProperty('old_value')
+  })
+})

--- a/packages/logging/src/audit/index.ts
+++ b/packages/logging/src/audit/index.ts
@@ -1,6 +1,6 @@
 import type { AuditDeps } from './emit.js'
 import { emitAudit } from './emit.js'
-import { AUTHN_SPECS, DATA_ACCESS_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
+import { AUTHN_SPECS, CONFIG_CHANGE_SPECS, DATA_ACCESS_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
 import type { AuditLogger } from './types.js'
 
 export type { AuditDeps } from './emit.js'
@@ -35,5 +35,9 @@ export const createAuditLogger = (deps: AuditDeps): AuditLogger => ({
     dataAccessed: input => emitAudit(deps, DATA_ACCESS_SPECS.dataAccessed, input),
     recordDownloaded: input => emitAudit(deps, DATA_ACCESS_SPECS.recordDownloaded, input),
     bulkExported: input => emitAudit(deps, DATA_ACCESS_SPECS.bulkExported, input),
+  },
+  configChange: {
+    securityConfigChanged: input => emitAudit(deps, CONFIG_CHANGE_SPECS.securityConfigChanged, input),
+    policyChanged: input => emitAudit(deps, CONFIG_CHANGE_SPECS.policyChanged, input),
   },
 })

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -211,3 +211,29 @@ export const DATA_ACCESS_SPECS = {
     },
   }),
 } satisfies Record<string, EventSpec>
+
+const configChange = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'configChange',
+  event,
+  ...spec,
+})
+
+// Admin actions: actor (`user_id`) and `client_ip` are scope-read. Log the
+// setting/policy and old/new values (callers keep secrets out — values are config).
+/** Application function & security-configuration change event specs. */
+export const CONFIG_CHANGE_SPECS = {
+  securityConfigChanged: configChange('securityConfigChanged', {
+    level: 'notice',
+    message: 'Security configuration changed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { setting: 'setting', oldValue: 'old_value', newValue: 'new_value' },
+  }),
+  policyChanged: configChange('policyChanged', {
+    level: 'notice',
+    message: 'Policy changed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { policyType: 'policy_type', summary: 'summary', oldValue: 'old_value', newValue: 'new_value' },
+  }),
+} satisfies Record<string, EventSpec>

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -19,6 +19,8 @@ export interface AuditLogger {
   userManagement: UserManagementAudit
   /** Data access, movement & export events. */
   dataAccess: DataAccessAudit
+  /** Application function & security-configuration change events. */
+  configChange: ConfigChangeAudit
 }
 
 /**
@@ -279,4 +281,44 @@ export interface BulkExportedInput extends AuditInputBase {
   recordCount: number
   /** The filters/parameters that scoped the export. */
   filters?: AuditContext
+}
+
+/**
+ * Application function & security-configuration change audit events
+ * (category `configChange`). Includes the org-level policy changes deferred
+ * from `userManagement` (password/access policy, ACLs, retention, logging).
+ *
+ * Admin actions, downstream of auth: actor `user_id` and `client_ip` are
+ * scope-read. Log *what* changed (and old/new values when non-sensitive),
+ * never secrets.
+ *
+ * @public
+ */
+export interface ConfigChangeAudit {
+  /** A security/compliance-affecting configuration setting changed. Fires at `notice`. */
+  securityConfigChanged(input: SecurityConfigChangedInput): void
+  /** An application policy changed (ACL, retention, logging, password, access). Fires at `notice`. */
+  policyChanged(input: PolicyChangedInput): void
+}
+
+/** Input for {@link ConfigChangeAudit.securityConfigChanged}. @public */
+export interface SecurityConfigChangedInput extends AuditInputBase {
+  /** The setting that changed, e.g. `session_timeout`, `mfa_required`. */
+  setting: string
+  /** The previous value, if non-sensitive and useful. */
+  oldValue?: unknown
+  /** The new value, if non-sensitive and useful. */
+  newValue?: unknown
+}
+
+/** Input for {@link ConfigChangeAudit.policyChanged}. @public */
+export interface PolicyChangedInput extends AuditInputBase {
+  /** The kind of policy, e.g. `acl`, `retention`, `logging`, `password`, `access`. */
+  policyType: string
+  /** A short human summary of the change, if useful. */
+  summary?: string
+  /** The previous value, if non-sensitive and useful. */
+  oldValue?: unknown
+  /** The new value, if non-sensitive and useful. */
+  newValue?: unknown
 }


### PR DESCRIPTION
## Summary

Adds the **`configChange`** audit category — `logger.audit.configChange.*` (ADR-0006).

## Events (all `notice`)

- **`securityConfigChanged`** — a security/compliance-affecting setting changed (`setting`, optional old/new value).
- **`policyChanged`** — an application policy changed (`policyType`: ACL, retention, logging, password, access; optional summary + old/new).

This is also the home for the **org-level policy changes deferred from `userManagement`** (password/access policy, ACLs, retention, logging settings) — per the dedup in ADR-0006.

## Design

- Admin actions, downstream of auth — actor (`user_id`) and `client_ip` are **scope-read**.
- Logs the setting/policy and **non-sensitive** old/new values (values are config; callers keep secrets out).

## Tests & changeset

2 new tests; a `.changeset/audit-config-change.md` entry. Full suite green; API report regenerated; lint/ci:report clean.

## Stack

Part of the audit-helper Graphite stack, based on **#62** (`dataAccess`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
