### PR TITLE
feat(logging): add the apiUsage audit category

### DIFF
--- a/.changeset/audit-api-usage.md
+++ b/.changeset/audit-api-usage.md
@@ -1,0 +1,9 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add the `apiUsage` audit category — `logger.audit.apiUsage.*`: `tokenIssued`,
+`tokenRefreshed`, `tokenInvalidated`, and `sensitiveEndpointAccessed`. Token
+identifiers are references, never the token value. Anomaly/abuse detection is
+deliberately excluded — that is a sink/SIEM concern over these lines, not
+something the app knows at log time.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -34,6 +34,14 @@ export interface ApiKeyChangedInput extends AuditInputBase {
 }
 
 // @public
+export interface ApiUsageAudit {
+    sensitiveEndpointAccessed(input: SensitiveEndpointAccessedInput): void;
+    tokenInvalidated(input: TokenInvalidatedInput): void;
+    tokenIssued(input: TokenIssuedInput): void;
+    tokenRefreshed(input: TokenRefreshedInput): void;
+}
+
+// @public
 export type AuditContext = Record<string, unknown>;
 
 // @public
@@ -44,6 +52,7 @@ export interface AuditInputBase {
 
 // @public
 export interface AuditLogger {
+    apiUsage: ApiUsageAudit;
     authn: AuthnAudit;
     configChange: ConfigChangeAudit;
     dataAccess: DataAccessAudit;
@@ -226,6 +235,13 @@ export interface SecurityConfigChangedInput extends AuditInputBase {
 }
 
 // @public
+export interface SensitiveEndpointAccessedInput extends AuditInputBase {
+    endpoint: string;
+    method: string;
+    params?: AuditContext;
+}
+
+// @public
 export function serializeError(err: Error): Record<string, unknown>;
 
 // @public
@@ -255,6 +271,24 @@ export interface SystemLoggerOptions {
     source?: string | null;
     traceId?: string | null;
     userId?: string;
+}
+
+// @public
+export interface TokenInvalidatedInput extends AuditInputBase {
+    reason: string;
+    tokenId: string;
+}
+
+// @public
+export interface TokenIssuedInput extends AuditInputBase {
+    scopes?: string[];
+    tokenId: string;
+    userId: string;
+}
+
+// @public
+export interface TokenRefreshedInput extends AuditInputBase {
+    tokenId: string;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -330,3 +330,15 @@ secrets.
 | ----------------------- | -------- | ------------------------------------------------------- |
 | `securityConfigChanged` | `notice` | `setting` _(opt: `oldValue`, `newValue`)_               |
 | `policyChanged`         | `notice` | `policyType` _(opt: `summary`, `oldValue`, `newValue`)_ |
+
+#### `apiUsage` — API token lifecycle & sensitive-endpoint access
+
+Anomaly/abuse detection is intentionally absent — the app does not know a call is
+anomalous at log time; that is a sink/SIEM concern _over_ these lines.
+
+| Event                       | Level    | Required fields                        |
+| --------------------------- | -------- | -------------------------------------- |
+| `tokenIssued`               | `notice` | `userId`, `tokenId` _(opt: `scopes`)_  |
+| `tokenRefreshed`            | `notice` | `tokenId`                              |
+| `tokenInvalidated`          | `notice` | `tokenId`, `reason`                    |
+| `sensitiveEndpointAccessed` | `notice` | `endpoint`, `method` _(opt: `params`)_ |

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -312,3 +312,37 @@ describe('audit.configChange', () => {
     expect(line.context as Record<string, unknown>).not.toHaveProperty('old_value')
   })
 })
+
+describe('audit.apiUsage', () => {
+  it('promotes the issued-for subject to user_id on tokenIssued', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/oauth/token',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+    }).audit.apiUsage.tokenIssued({ userId: 'svc_1', tokenId: 'tok_1', scopes: ['read', 'write'] })
+    const line = at(0)
+    expect(line).toMatchObject({
+      audit: true,
+      category: 'apiUsage',
+      event: 'tokenIssued',
+      user_id: 'svc_1',
+      context: { token_id: 'tok_1', scopes: ['read', 'write'] },
+    })
+  })
+
+  it('records sensitive-endpoint access with sanitised params in context', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/api',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+      userId: 'u_1',
+    }).audit.apiUsage.sensitiveEndpointAccessed({
+      endpoint: '/api/admin/export',
+      method: 'POST',
+      params: { scope: 'all' },
+    })
+    expect(at(0).context).toMatchObject({ endpoint: '/api/admin/export', method: 'POST', params: { scope: 'all' } })
+  })
+})

--- a/packages/logging/src/audit/index.ts
+++ b/packages/logging/src/audit/index.ts
@@ -1,6 +1,6 @@
 import type { AuditDeps } from './emit.js'
 import { emitAudit } from './emit.js'
-import { AUTHN_SPECS, CONFIG_CHANGE_SPECS, DATA_ACCESS_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
+import { API_USAGE_SPECS, AUTHN_SPECS, CONFIG_CHANGE_SPECS, DATA_ACCESS_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
 import type { AuditLogger } from './types.js'
 
 export type { AuditDeps } from './emit.js'
@@ -39,5 +39,11 @@ export const createAuditLogger = (deps: AuditDeps): AuditLogger => ({
   configChange: {
     securityConfigChanged: input => emitAudit(deps, CONFIG_CHANGE_SPECS.securityConfigChanged, input),
     policyChanged: input => emitAudit(deps, CONFIG_CHANGE_SPECS.policyChanged, input),
+  },
+  apiUsage: {
+    tokenIssued: input => emitAudit(deps, API_USAGE_SPECS.tokenIssued, input),
+    tokenRefreshed: input => emitAudit(deps, API_USAGE_SPECS.tokenRefreshed, input),
+    tokenInvalidated: input => emitAudit(deps, API_USAGE_SPECS.tokenInvalidated, input),
+    sensitiveEndpointAccessed: input => emitAudit(deps, API_USAGE_SPECS.sensitiveEndpointAccessed, input),
   },
 })

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -237,3 +237,43 @@ export const CONFIG_CHANGE_SPECS = {
     contextFields: { policyType: 'policy_type', summary: 'summary', oldValue: 'old_value', newValue: 'new_value' },
   }),
 } satisfies Record<string, EventSpec>
+
+const apiUsage = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'apiUsage',
+  event,
+  ...spec,
+})
+
+// `tokenIssued` *produces* the subject, so `userId` is payload-required and
+// promoted; the others run in an authenticated context (`user_id` scope-read).
+/** API usage event specs. */
+export const API_USAGE_SPECS = {
+  tokenIssued: apiUsage('tokenIssued', {
+    level: 'notice',
+    message: 'API token issued',
+    promote: { userId: 'user_id' },
+    requiredScope: ['client_ip'],
+    contextFields: { tokenId: 'token_id', scopes: 'scopes' },
+  }),
+  tokenRefreshed: apiUsage('tokenRefreshed', {
+    level: 'notice',
+    message: 'API token refreshed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { tokenId: 'token_id' },
+  }),
+  tokenInvalidated: apiUsage('tokenInvalidated', {
+    level: 'notice',
+    message: 'API token invalidated',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { tokenId: 'token_id', reason: 'reason' },
+  }),
+  sensitiveEndpointAccessed: apiUsage('sensitiveEndpointAccessed', {
+    level: 'notice',
+    message: 'Sensitive endpoint accessed',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { endpoint: 'endpoint', method: 'method', params: 'params' },
+  }),
+} satisfies Record<string, EventSpec>

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -21,6 +21,8 @@ export interface AuditLogger {
   dataAccess: DataAccessAudit
   /** Application function & security-configuration change events. */
   configChange: ConfigChangeAudit
+  /** API usage events — token lifecycle and sensitive-endpoint access. */
+  apiUsage: ApiUsageAudit
 }
 
 /**
@@ -321,4 +323,58 @@ export interface PolicyChangedInput extends AuditInputBase {
   oldValue?: unknown
   /** The new value, if non-sensitive and useful. */
   newValue?: unknown
+}
+
+/**
+ * API usage audit events (category `apiUsage`).
+ *
+ * Covers API token lifecycle and access to sensitive endpoints. Anomaly/abuse
+ * detection is intentionally absent — the app does not know a call is anomalous
+ * at log time; that is a sink/SIEM concern *over* these lines (ADR-0007).
+ *
+ * @public
+ */
+export interface ApiUsageAudit {
+  /** An API token was issued. Fires at `notice`. */
+  tokenIssued(input: TokenIssuedInput): void
+  /** An API token was refreshed. Fires at `notice`. */
+  tokenRefreshed(input: TokenRefreshedInput): void
+  /** An API token was invalidated/revoked. Fires at `notice`. */
+  tokenInvalidated(input: TokenInvalidatedInput): void
+  /** A sensitive endpoint was accessed. Fires at `notice`. */
+  sensitiveEndpointAccessed(input: SensitiveEndpointAccessedInput): void
+}
+
+/** Input for {@link ApiUsageAudit.tokenIssued}. @public */
+export interface TokenIssuedInput extends AuditInputBase {
+  /** The subject the token was issued for. Promoted to `user_id`. */
+  userId: string
+  /** The token's identifier — a reference, never the token value. */
+  tokenId: string
+  /** The scopes/permissions granted, if any. */
+  scopes?: string[]
+}
+
+/** Input for {@link ApiUsageAudit.tokenRefreshed}. @public */
+export interface TokenRefreshedInput extends AuditInputBase {
+  /** The refreshed token's identifier (a reference, not the token value). */
+  tokenId: string
+}
+
+/** Input for {@link ApiUsageAudit.tokenInvalidated}. @public */
+export interface TokenInvalidatedInput extends AuditInputBase {
+  /** The invalidated token's identifier (a reference, not the token value). */
+  tokenId: string
+  /** Why it was invalidated, e.g. `revoked`, `expired`, `rotated`. */
+  reason: string
+}
+
+/** Input for {@link ApiUsageAudit.sensitiveEndpointAccessed}. @public */
+export interface SensitiveEndpointAccessedInput extends AuditInputBase {
+  /** The endpoint accessed, e.g. `/api/admin/export`. */
+  endpoint: string
+  /** The HTTP method. */
+  method: string
+  /** Request parameters — caller-sanitised; keep secrets/PII out. */
+  params?: AuditContext
 }


### PR DESCRIPTION
## Summary

Adds the **`apiUsage`** audit category — `logger.audit.apiUsage.*` (ADR-0006).

## Events (all `notice`)

- **`tokenIssued`** — an API token was issued (subject `userId` → promoted to `user_id`; `tokenId`; optional scopes).
- **`tokenRefreshed`** / **`tokenInvalidated`** — token lifecycle (`tokenId`, reason).
- **`sensitiveEndpointAccessed`** — access to a sensitive endpoint (endpoint, method, sanitised params).

## Design

- `tokenIssued` **produces** the subject, so `userId` is payload-required and promoted; the rest are **scope-read**.
- Token identifiers are **references, never the token value**.
- **Anomaly/abuse detection is deliberately excluded** — the app doesn't know a call is anomalous at log time; that's a sink/SIEM concern *over* these lines.

## Tests & changeset

2 new tests; a `.changeset/audit-api-usage.md` entry. Full suite green; API report regenerated; lint/ci:report clean.

## Stack

Part of the audit-helper Graphite stack, based on **#63** (`configChange`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
