### PR TITLE
feat(logging): add the failures audit category

### DIFF
--- a/.changeset/audit-failures.md
+++ b/.changeset/audit-failures.md
@@ -1,0 +1,10 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add the `failures` audit category — `logger.audit.failures.*`: `accessDenied`,
+`privilegeEscalationDenied`, and `sensitiveActionBlocked`. These are *handled*,
+security-relevant denials and fire at `warn` (the control worked).
+`accessDenied` may be unauthenticated, so its actor is optional. Application
+*errors* still go through the base `error()`, and anomaly detection remains a
+sink concern.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -5,6 +5,14 @@
 ```ts
 
 // @public
+export interface AccessDeniedInput extends AuditInputBase {
+    attemptedAction?: string;
+    reason: string;
+    resource: string;
+    userId?: string;
+}
+
+// @public
 export interface AccountCreatedInput extends AuditInputBase {
     targetUserId: string;
 }
@@ -56,6 +64,7 @@ export interface AuditLogger {
     authn: AuthnAudit;
     configChange: ConfigChangeAudit;
     dataAccess: DataAccessAudit;
+    failures: FailuresAudit;
     userManagement: UserManagementAudit;
 }
 
@@ -113,6 +122,13 @@ export interface DataAccessedInput extends AuditInputBase {
     classification: string;
     resourceId: string;
     resourceType: string;
+}
+
+// @public
+export interface FailuresAudit {
+    accessDenied(input: AccessDeniedInput): void;
+    privilegeEscalationDenied(input: PrivilegeEscalationDeniedInput): void;
+    sensitiveActionBlocked(input: SensitiveActionBlockedInput): void;
 }
 
 // @public
@@ -211,6 +227,13 @@ export interface PolicyChangedInput extends AuditInputBase {
 }
 
 // @public
+export interface PrivilegeEscalationDeniedInput extends AuditInputBase {
+    attemptedRole: string;
+    reason: string;
+    targetUserId?: string;
+}
+
+// @public
 export interface RecordDownloadedInput extends AuditInputBase {
     classification: string;
     method: string;
@@ -232,6 +255,12 @@ export interface SecurityConfigChangedInput extends AuditInputBase {
     newValue?: unknown;
     oldValue?: unknown;
     setting: string;
+}
+
+// @public
+export interface SensitiveActionBlockedInput extends AuditInputBase {
+    blockedAction: string;
+    reason: string;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -342,3 +342,14 @@ anomalous at log time; that is a sink/SIEM concern _over_ these lines.
 | `tokenRefreshed`            | `notice` | `tokenId`                              |
 | `tokenInvalidated`          | `notice` | `tokenId`, `reason`                    |
 | `sensitiveEndpointAccessed` | `notice` | `endpoint`, `method` _(opt: `params`)_ |
+
+#### `failures` — handled security denials
+
+_Handled_, security-relevant denials, so they fire at `warn` (the control
+worked). Application _errors_ go through the base `error()`, not here.
+
+| Event                       | Level  | Required fields                                           |
+| --------------------------- | ------ | --------------------------------------------------------- |
+| `accessDenied`              | `warn` | `resource`, `reason` _(opt: `userId`, `attemptedAction`)_ |
+| `privilegeEscalationDenied` | `warn` | `attemptedRole`, `reason` _(opt: `targetUserId`)_         |
+| `sensitiveActionBlocked`    | `warn` | `blockedAction`, `reason`                                 |

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -346,3 +346,48 @@ describe('audit.apiUsage', () => {
     expect(at(0).context).toMatchObject({ endpoint: '/api/admin/export', method: 'POST', params: { scope: 'all' } })
   })
 })
+
+describe('audit.failures', () => {
+  it('fires denials at warn', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/admin',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+      userId: 'u_1',
+    }).audit.failures.privilegeEscalationDenied({
+      attemptedRole: 'admin',
+      reason: 'not_permitted',
+      targetUserId: 'u_2',
+    })
+    const line = at(0)
+    expect(line).toMatchObject({
+      level: 'WARN',
+      audit: true,
+      category: 'failures',
+      event: 'privilegeEscalationDenied',
+      user_id: 'u_1',
+      context: { attempted_role: 'admin', reason: 'not_permitted', target_user_id: 'u_2' },
+    })
+  })
+
+  it('allows accessDenied without an authenticated actor (only client_ip required)', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/admin',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+    }).audit.failures.accessDenied({
+      resource: '/admin',
+      reason: 'unauthenticated',
+    })
+    const lines = entries()
+    expect(lines).toHaveLength(1) // no missing-scope diagnostic (user_id not required)
+    expect(lines[0]).toMatchObject({
+      level: 'WARN',
+      event: 'accessDenied',
+      context: { resource: '/admin', reason: 'unauthenticated' },
+    })
+    expect(lines[0]).not.toHaveProperty('user_id')
+  })
+})

--- a/packages/logging/src/audit/index.ts
+++ b/packages/logging/src/audit/index.ts
@@ -1,6 +1,13 @@
 import type { AuditDeps } from './emit.js'
 import { emitAudit } from './emit.js'
-import { API_USAGE_SPECS, AUTHN_SPECS, CONFIG_CHANGE_SPECS, DATA_ACCESS_SPECS, USER_MANAGEMENT_SPECS } from './spec.js'
+import {
+  API_USAGE_SPECS,
+  AUTHN_SPECS,
+  CONFIG_CHANGE_SPECS,
+  DATA_ACCESS_SPECS,
+  FAILURES_SPECS,
+  USER_MANAGEMENT_SPECS,
+} from './spec.js'
 import type { AuditLogger } from './types.js'
 
 export type { AuditDeps } from './emit.js'
@@ -45,5 +52,10 @@ export const createAuditLogger = (deps: AuditDeps): AuditLogger => ({
     tokenRefreshed: input => emitAudit(deps, API_USAGE_SPECS.tokenRefreshed, input),
     tokenInvalidated: input => emitAudit(deps, API_USAGE_SPECS.tokenInvalidated, input),
     sensitiveEndpointAccessed: input => emitAudit(deps, API_USAGE_SPECS.sensitiveEndpointAccessed, input),
+  },
+  failures: {
+    accessDenied: input => emitAudit(deps, FAILURES_SPECS.accessDenied, input),
+    privilegeEscalationDenied: input => emitAudit(deps, FAILURES_SPECS.privilegeEscalationDenied, input),
+    sensitiveActionBlocked: input => emitAudit(deps, FAILURES_SPECS.sensitiveActionBlocked, input),
   },
 })

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -277,3 +277,36 @@ export const API_USAGE_SPECS = {
     contextFields: { endpoint: 'endpoint', method: 'method', params: 'params' },
   }),
 } satisfies Record<string, EventSpec>
+
+const failures = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'failures',
+  event,
+  ...spec,
+})
+
+// Handled security denials — all `warn` (the control fired). `accessDenied` may
+// be unauthenticated, so `userId` is optional/promoted; the rest are scope-read.
+/** Security failure event specs. */
+export const FAILURES_SPECS = {
+  accessDenied: failures('accessDenied', {
+    level: 'warn',
+    message: 'Access denied',
+    promote: { userId: 'user_id' },
+    requiredScope: ['client_ip'],
+    contextFields: { resource: 'resource', reason: 'reason', attemptedAction: 'attempted_action' },
+  }),
+  privilegeEscalationDenied: failures('privilegeEscalationDenied', {
+    level: 'warn',
+    message: 'Privilege escalation denied',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { attemptedRole: 'attempted_role', reason: 'reason', targetUserId: 'target_user_id' },
+  }),
+  sensitiveActionBlocked: failures('sensitiveActionBlocked', {
+    level: 'warn',
+    message: 'Sensitive action blocked',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { blockedAction: 'blocked_action', reason: 'reason' },
+  }),
+} satisfies Record<string, EventSpec>

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -23,6 +23,8 @@ export interface AuditLogger {
   configChange: ConfigChangeAudit
   /** API usage events — token lifecycle and sensitive-endpoint access. */
   apiUsage: ApiUsageAudit
+  /** Security failures — handled, security-relevant denials. */
+  failures: FailuresAudit
 }
 
 /**
@@ -377,4 +379,51 @@ export interface SensitiveEndpointAccessedInput extends AuditInputBase {
   method: string
   /** Request parameters — caller-sanitised; keep secrets/PII out. */
   params?: AuditContext
+}
+
+/**
+ * Security failure audit events (category `failures`) — *handled*, security-
+ * relevant denials, so they fire at `warn` (the control worked). Application
+ * *errors* go through the base `error()`; anomaly/abuse detection is a sink
+ * concern (ADR-0007).
+ *
+ * @public
+ */
+export interface FailuresAudit {
+  /** An unauthorized access attempt was denied. Fires at `warn`. */
+  accessDenied(input: AccessDeniedInput): void
+  /** A privilege-escalation attempt was denied. Fires at `warn`. */
+  privilegeEscalationDenied(input: PrivilegeEscalationDeniedInput): void
+  /** A sensitive action was blocked (e.g. a blocked export). Fires at `warn`. */
+  sensitiveActionBlocked(input: SensitiveActionBlockedInput): void
+}
+
+/** Input for {@link FailuresAudit.accessDenied}. @public */
+export interface AccessDeniedInput extends AuditInputBase {
+  /** What access was denied to, e.g. `/admin`, `record:r_1`. */
+  resource: string
+  /** Why access was denied, e.g. `insufficient_role`, `not_owner`. */
+  reason: string
+  /** The acting user, if authenticated (an attempt may be unauthenticated). Promoted to `user_id`. */
+  userId?: string
+  /** The action that was attempted, if useful. */
+  attemptedAction?: string
+}
+
+/** Input for {@link FailuresAudit.privilegeEscalationDenied}. @public */
+export interface PrivilegeEscalationDeniedInput extends AuditInputBase {
+  /** The role/permission the actor tried to gain. */
+  attemptedRole: string
+  /** Why it was denied. */
+  reason: string
+  /** The account targeted, if the escalation was on another user. Emitted as `context.target_user_id`. */
+  targetUserId?: string
+}
+
+/** Input for {@link FailuresAudit.sensitiveActionBlocked}. @public */
+export interface SensitiveActionBlockedInput extends AuditInputBase {
+  /** The action that was blocked, e.g. `bulk_export`, `delete_account`. */
+  blockedAction: string
+  /** Why it was blocked. */
+  reason: string
 }


### PR DESCRIPTION
## Summary

Adds the **`failures`** audit category — `logger.audit.failures.*` (ADR-0006) — the security-relevant, *handled* denials. Completes Tier-1 of the compliance taxonomy (categories 1–6).

## Events (all `warn`)

- **`accessDenied`** — an unauthorized access attempt was denied (resource, reason; actor optional — may be unauthenticated).
- **`privilegeEscalationDenied`** — a privilege-escalation attempt was denied (attempted role, reason, optional target).
- **`sensitiveActionBlocked`** — a sensitive action was blocked, e.g. a blocked export (action, reason).

## Design

- All fire at **`warn`** — the control *worked*; these are handled denials, not operation failures.
- `accessDenied` allows an **unauthenticated** actor (`user_id` optional; only `client_ip` required).
- Application **errors** still go through the base `error()`; **anomaly detection** remains a sink concern.

## Tests & changeset

2 new tests (warn level, unauthenticated actor); a `.changeset/audit-failures.md` entry. Full suite green; API report regenerated; lint/ci:report clean.

## Stack

Top of the audit-helper Graphite stack, based on **#64** (`apiUsage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
