### PR TITLE
feat(logging): add the resource audit category

### DIFF
--- a/.changeset/audit-resource.md
+++ b/.changeset/audit-resource.md
@@ -1,0 +1,13 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add the `resource` audit category — `logger.audit.resource.*`: `created`,
+`updated`, `deleted`, and `ownershipTransferred`. This is the **mutation** side
+of generic business entities (forms, projects, documents, …), complementing
+`dataAccess` (read/export) and `userManagement` (accounts). Downstream actions:
+the actor (`user_id`) and `client_ip` are scope-read; `ownershipTransferred`
+records the previous/new owner as `context.from_owner_id`/`to_owner_id` (owners
+are generic — user, team, org — not necessarily users) while the top-level
+`user_id` stays the actor who performed it. Logs field names on update, never
+values.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -65,6 +65,7 @@ export interface AuditLogger {
     configChange: ConfigChangeAudit;
     dataAccess: DataAccessAudit;
     failures: FailuresAudit;
+    resource: ResourceAudit;
     userManagement: UserManagementAudit;
 }
 
@@ -213,6 +214,15 @@ export interface MfaSettingChangedInput extends AuditInputBase {
 }
 
 // @public
+export interface OwnershipTransferredInput extends AuditInputBase {
+    fromOwnerId: string;
+    ownerType?: string;
+    resourceId: string;
+    resourceType: string;
+    toOwnerId: string;
+}
+
+// @public
 export interface PasswordResetInput extends AuditInputBase {
     initiatedBy: 'self' | 'admin';
     targetUserId: string;
@@ -241,6 +251,34 @@ export interface RecordDownloadedInput extends AuditInputBase {
     resourceType?: string;
     role?: string;
     sizeBytes: number;
+}
+
+// @public
+export interface ResourceAudit {
+    created(input: ResourceCreatedInput): void;
+    deleted(input: ResourceDeletedInput): void;
+    ownershipTransferred(input: OwnershipTransferredInput): void;
+    updated(input: ResourceUpdatedInput): void;
+}
+
+// @public
+export interface ResourceCreatedInput extends AuditInputBase {
+    resourceId: string;
+    resourceType: string;
+}
+
+// @public
+export interface ResourceDeletedInput extends AuditInputBase {
+    reason?: string;
+    resourceId: string;
+    resourceType: string;
+}
+
+// @public
+export interface ResourceUpdatedInput extends AuditInputBase {
+    changedFields: string[];
+    resourceId: string;
+    resourceType: string;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -353,3 +353,17 @@ worked). Application _errors_ go through the base `error()`, not here.
 | `accessDenied`              | `warn` | `resource`, `reason` _(opt: `userId`, `attemptedAction`)_ |
 | `privilegeEscalationDenied` | `warn` | `attemptedRole`, `reason` _(opt: `targetUserId`)_         |
 | `sensitiveActionBlocked`    | `warn` | `blockedAction`, `reason`                                 |
+
+#### `resource` — entity lifecycle
+
+The **mutation** side of generic business entities (forms, projects, documents,
+…) — complements `dataAccess` (read/export) and `userManagement` (accounts).
+Downstream of auth: the actor `user_id` and `client_ip` are scope-read. Log the
+resource type/id and _what_ changed (field names), never the contents.
+
+| Event                  | Level    | Required fields                                                               |
+| ---------------------- | -------- | ----------------------------------------------------------------------------- |
+| `created`              | `notice` | `resourceType`, `resourceId`                                                  |
+| `updated`              | `notice` | `resourceType`, `resourceId`, `changedFields`                                 |
+| `deleted`              | `notice` | `resourceType`, `resourceId` _(opt: `reason`)_                                |
+| `ownershipTransferred` | `notice` | `resourceType`, `resourceId`, `fromOwnerId`, `toOwnerId` _(opt: `ownerType`)_ |

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -391,3 +391,44 @@ describe('audit.failures', () => {
     expect(lines[0]).not.toHaveProperty('user_id')
   })
 })
+
+describe('audit.resource', () => {
+  const reqLogger = () =>
+    createBaseLogger({ traceId: null, path: '/forms', clientIp: '1.2.3.4', userAgent: 'jest', userId: 'u_1' })
+
+  it('records a resource update with changed field names in context', () => {
+    reqLogger().audit.resource.updated({ resourceType: 'form', resourceId: 'f_1', changedFields: ['title', 'status'] })
+    const line = at(0)
+    expect(line).toMatchObject({
+      level: 'NOTICE',
+      audit: true,
+      category: 'resource',
+      event: 'updated',
+      user_id: 'u_1',
+      context: { resource_type: 'form', resource_id: 'f_1', changed_fields: ['title', 'status'] },
+    })
+  })
+
+  it('records an ownership transfer with from/to in context (actor stays the doer)', () => {
+    reqLogger().audit.resource.ownershipTransferred({
+      resourceType: 'form',
+      resourceId: 'f_1',
+      fromOwnerId: 'team_a',
+      toOwnerId: 'team_b',
+      ownerType: 'team',
+    })
+    const line = at(0)
+    expect(line).toMatchObject({
+      event: 'ownershipTransferred',
+      user_id: 'u_1', // the actor who performed the transfer
+      context: {
+        resource_type: 'form',
+        resource_id: 'f_1',
+        from_owner_id: 'team_a',
+        to_owner_id: 'team_b',
+        owner_type: 'team',
+      },
+    })
+    expect(line).not.toHaveProperty('from_owner_id') // from/to live in context, not root
+  })
+})

--- a/packages/logging/src/audit/index.ts
+++ b/packages/logging/src/audit/index.ts
@@ -6,6 +6,7 @@ import {
   CONFIG_CHANGE_SPECS,
   DATA_ACCESS_SPECS,
   FAILURES_SPECS,
+  RESOURCE_SPECS,
   USER_MANAGEMENT_SPECS,
 } from './spec.js'
 import type { AuditLogger } from './types.js'
@@ -57,5 +58,11 @@ export const createAuditLogger = (deps: AuditDeps): AuditLogger => ({
     accessDenied: input => emitAudit(deps, FAILURES_SPECS.accessDenied, input),
     privilegeEscalationDenied: input => emitAudit(deps, FAILURES_SPECS.privilegeEscalationDenied, input),
     sensitiveActionBlocked: input => emitAudit(deps, FAILURES_SPECS.sensitiveActionBlocked, input),
+  },
+  resource: {
+    created: input => emitAudit(deps, RESOURCE_SPECS.created, input),
+    updated: input => emitAudit(deps, RESOURCE_SPECS.updated, input),
+    deleted: input => emitAudit(deps, RESOURCE_SPECS.deleted, input),
+    ownershipTransferred: input => emitAudit(deps, RESOURCE_SPECS.ownershipTransferred, input),
   },
 })

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -310,3 +310,49 @@ export const FAILURES_SPECS = {
     contextFields: { blockedAction: 'blocked_action', reason: 'reason' },
   }),
 } satisfies Record<string, EventSpec>
+
+const resource = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): EventSpec => ({
+  category: 'resource',
+  event,
+  ...spec,
+})
+
+// Generic entity lifecycle (the mutation side; `dataAccess` is the read side).
+// Downstream admin/owner actions: actor (`user_id`) and `client_ip` scope-read.
+/** Resource/entity lifecycle event specs. */
+export const RESOURCE_SPECS = {
+  created: resource('created', {
+    level: 'notice',
+    message: 'Resource created',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { resourceType: 'resource_type', resourceId: 'resource_id' },
+  }),
+  updated: resource('updated', {
+    level: 'notice',
+    message: 'Resource updated',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { resourceType: 'resource_type', resourceId: 'resource_id', changedFields: 'changed_fields' },
+  }),
+  deleted: resource('deleted', {
+    level: 'notice',
+    message: 'Resource deleted',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: { resourceType: 'resource_type', resourceId: 'resource_id', reason: 'reason' },
+  }),
+  ownershipTransferred: resource('ownershipTransferred', {
+    level: 'notice',
+    message: 'Resource ownership transferred',
+    promote: {},
+    requiredScope: ['user_id', 'client_ip'],
+    contextFields: {
+      resourceType: 'resource_type',
+      resourceId: 'resource_id',
+      fromOwnerId: 'from_owner_id',
+      toOwnerId: 'to_owner_id',
+      ownerType: 'owner_type',
+    },
+  }),
+} satisfies Record<string, EventSpec>

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -25,6 +25,8 @@ export interface AuditLogger {
   apiUsage: ApiUsageAudit
   /** Security failures — handled, security-relevant denials. */
   failures: FailuresAudit
+  /** Resource/entity lifecycle — create, update, delete, ownership transfer. */
+  resource: ResourceAudit
 }
 
 /**
@@ -426,4 +428,68 @@ export interface SensitiveActionBlockedInput extends AuditInputBase {
   blockedAction: string
   /** Why it was blocked. */
   reason: string
+}
+
+/**
+ * Resource/entity lifecycle audit events (category `resource`).
+ *
+ * The **mutation** side of generic business entities (forms, projects,
+ * documents, …) — complements `dataAccess` (the read/export side) and
+ * `userManagement` (accounts specifically). Downstream of auth: the actor
+ * (`user_id`) and `client_ip` are scope-read. Log the resource type/id and
+ * *what* changed (field names), never the contents.
+ *
+ * @public
+ */
+export interface ResourceAudit {
+  /** A resource was created. Fires at `notice`. */
+  created(input: ResourceCreatedInput): void
+  /** A resource was updated. Fires at `notice`. */
+  updated(input: ResourceUpdatedInput): void
+  /** A resource was deleted. Fires at `notice`. */
+  deleted(input: ResourceDeletedInput): void
+  /** A resource's ownership was transferred to another user. Fires at `notice`. */
+  ownershipTransferred(input: OwnershipTransferredInput): void
+}
+
+/** Input for {@link ResourceAudit.created}. @public */
+export interface ResourceCreatedInput extends AuditInputBase {
+  /** The kind of resource, e.g. `form`, `project`, `document`. */
+  resourceType: string
+  /** The resource's identifier. */
+  resourceId: string
+}
+
+/** Input for {@link ResourceAudit.updated}. @public */
+export interface ResourceUpdatedInput extends AuditInputBase {
+  /** The kind of resource, e.g. `form`, `project`, `document`. */
+  resourceType: string
+  /** The resource's identifier. */
+  resourceId: string
+  /** The names of the fields that changed — never their values. */
+  changedFields: string[]
+}
+
+/** Input for {@link ResourceAudit.deleted}. @public */
+export interface ResourceDeletedInput extends AuditInputBase {
+  /** The kind of resource, e.g. `form`, `project`, `document`. */
+  resourceType: string
+  /** The resource's identifier. */
+  resourceId: string
+  /** Why it was deleted (and/or soft vs hard), if useful. */
+  reason?: string
+}
+
+/** Input for {@link ResourceAudit.ownershipTransferred}. @public */
+export interface OwnershipTransferredInput extends AuditInputBase {
+  /** The kind of resource, e.g. `form`, `project`, `document`. */
+  resourceType: string
+  /** The resource's identifier. */
+  resourceId: string
+  /** The previous owner — an opaque reference (user, team, org, …), not necessarily a user. Emitted as `context.from_owner_id`. */
+  fromOwnerId: string
+  /** The new owner — an opaque reference (user, team, org, …). Emitted as `context.to_owner_id`. */
+  toOwnerId: string
+  /** What kind of owner, if useful, e.g. `user`, `team`, `org`. Emitted as `context.owner_type`. */
+  ownerType?: string
 }


### PR DESCRIPTION
## Summary

Adds the **`resource`** audit category — `logger.audit.resource.*` (ADR-0006) — the **mutation/lifecycle** side of generic business entities (forms, projects, documents, …). Fills the gap the existing categories left: `dataAccess` covers *read/export*, `userManagement` covers *accounts* — neither covers create/update/delete/transfer of an arbitrary domain entity. ADR-0001 itself cited "mutating a critical resource" and "ownership transfer" as audit-worthy.

## Events (all `notice`)

- **`created`** — `resourceType`, `resourceId`.
- **`updated`** — `resourceType`, `resourceId`, `changedFields` (names, **not** values).
- **`deleted`** — `resourceType`, `resourceId`, `reason?`.
- **`ownershipTransferred`** — `resourceType`, `resourceId`, `fromOwnerId`, `toOwnerId`, `ownerType?`.

## Design

- **Downstream actions** — the actor (`user_id`) and `client_ip` are **scope-read**.
- **Generic owners** — `ownershipTransferred` uses `fromOwnerId`/`toOwnerId` (+ optional `ownerType`) because an owner need not be a user (could be a team, org, …). They land in `context.from_owner_id`/`to_owner_id`; the top-level `user_id` stays the **actor** who performed the transfer. (Named `ownerId`, not `resourceId`, to avoid colliding with the transferred resource's id.)
- Logs **what** changed (field/resource ids), never the contents.

## Distinction from neighbours

| category | side |
|---|---|
| `resource` | **mutation** — create / update / delete / transfer |
| `dataAccess` | read / download / export |
| `userManagement` | accounts & permissions specifically |

## Tests & changeset

2 new tests (update field-names, ownership transfer from/to in context); `.changeset/audit-resource.md`. Full suite green; API report regenerated; lint/ci:report clean.

## Stack

Top of the audit-helper Graphite stack, based on **#65** (`failures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
