### PR TITLE
ci: run tests, linting, and codeql on every PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["develop"]
   pull_request:
-    branches: ["develop"]
   schedule:
     - cron: "0 10 * * *"
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,9 +1,9 @@
 name: Linting
 
 on:
+  pull_request:
   push:
-    branches-ignore:
-      - develop
+    branches: [develop]
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   pull_request:
-    branches: [develop]
   push:
     branches: [develop]
 


### PR DESCRIPTION
## Summary

Update the GitHub Actions workflows so tests, linting, and CodeQL run on **every PR** (and on each new commit pushed to a PR), instead of only on PRs targeting `develop`. This unblocks Graphite stacked PRs, whose intermediate PRs target other feature branches rather than `develop`.

## Changes

| Workflow | Before | After |
|---|---|---|
| `tests.yml` | `pull_request: branches: [develop]` | `pull_request:` (any base branch) |
| `codeql.yml` | `pull_request: branches: ["develop"]` | `pull_request:` (any base branch) |
| `linting.yml` | only `push: branches-ignore: [develop]` | `pull_request:` + `push: branches: [develop]` |

## Notes

- Removing the `branches:` filter on `pull_request` lets each workflow fire for any base branch, so stacked PRs get CI.
- GitHub's `pull_request` event includes the `synchronize` activity type, so new commits on a PR re-trigger CI automatically.
- `push: branches: [develop]` is retained so develop still runs checks on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)