### PR TITLE
fix(logging): merge scoped context into audit lines

### DIFF
--- a/.changeset/audit-scoped-context.md
+++ b/.changeset/audit-scoped-context.md
@@ -1,0 +1,10 @@
+---
+'@opengovsg/starter-kitty-logging': patch
+---
+
+Merge the logger's scoped context into audit lines
+
+`logger.scope({ context }).audit.*({ context })` now merges the scoped context
+into the emitted audit line (low to high: scoped, event fields, per-call),
+instead of dropping it. The merged context passes the same Context guard as a
+routine line. See ADR-0008.

--- a/docs/adr/0007-fixed-shape-audit-helpers.md
+++ b/docs/adr/0007-fixed-shape-audit-helpers.md
@@ -1,7 +1,7 @@
 # 7. Fixed-shape audit helpers
 
 Date: 2026-06-24
-Status: Accepted
+Status: Accepted (amended by ADR-0008: audit lines compose scoped context)
 
 ## Context
 

--- a/docs/adr/0008-audit-lines-compose-scoped-context.md
+++ b/docs/adr/0008-audit-lines-compose-scoped-context.md
@@ -1,0 +1,89 @@
+# 8. Audit lines compose scoped context
+
+Date: 2026-06-30
+Status: Accepted
+Amends: ADR-0007 (fixed-shape audit helpers)
+
+## Context
+
+ADR-0007 built the audit-helper layer: each event promotes its canonical fields
+to their wire position, stamps the `audit`/`category`/`event` Controlled fields,
+and lands its event-specific fields plus a free-form per-call `context` in the
+`context` bag. It is silent on one thing: what happens to the **Context** a
+caller has already bound to the logger via `scope({ context })` / `withContext`
+/ `setContext`.
+
+The base (routine) path merges that scoped Context into every line
+(`mergeContext(this.context, input.context)`). The audit path did not - the
+injected `emit` callback wrote the audit fields straight to the pino child,
+bypassing the base's context tail entirely. So
+`logger.scope({ action, context: { a } }).audit.x({ context: { b } })` emitted
+only `{ b }` (plus event fields); the scoped `{ a }` silently vanished. For a
+"who did what to which resource" line, dropping the ambient request facets an
+auditor most wants is exactly the wrong default.
+
+## Decision
+
+**An audit line composes the logger's scoped Context, the same way a routine
+line does.** The assembled audit Context is, low precedence to high:
+
+1. the logger's scoped **Context** (`scope`/`withContext`/`setContext`),
+2. the event's standard `contextFields`,
+3. the per-call `context`.
+
+"More specific wins" - a per-call key overrides an event field, which overrides
+an ambient scoped key. A real clash between (1) and (2) is near-impossible
+(event field names are event-specific; scoped Context is request facets), and
+where it ever happens the more-specific value is the right tiebreak.
+
+**The assembled Context passes the same Context guard as any line.** Once
+arbitrary scoped Context can ride an audit line, the oversized/unserialisable
+risk the guard exists for applies to audit lines too - and they land in
+WORM/retention storage, where a malformed line is worse. The guard runs
+uniformly; audit lines are not a hole in it.
+
+**`LoggerImpl` owns the merge and the guard; the audit module stays pure
+assembly.** Rather than teach the audit module to read scope and call
+`serializeContext` (option A), the injected `emit` callback performs the
+scoped-Context merge and runs the guard before writing to pino - the same
+context tail the routine path uses. The audit module keeps its ADR-0007 charter:
+it assembles event fields and hands a Context bag to `emit`, ignorant of scope,
+pino, and the guard. One chokepoint for "Context becomes a wire field," shared
+by both paths; the diagnostic lines the audit module emits inherit scoped
+Context for free.
+
+This refines, and does not reverse, ADR-0007. Promotion of canonical fields,
+the Controlled-field stamping, and `contextFields`-then-per-call ordering all
+stand; this ADR adds the scoped-Context layer beneath them and the guard above.
+
+## Considered alternatives
+
+- **Audit lines isolated from scoped Context** (rejected) - keep an audit line
+  fully self-described, immune to inheriting unvetted ambient keys (a PII-leak
+  guard for WORM storage). Rejected: the request facets bound at `scope()` are
+  precisely the who/where context a compliance reader needs, and PII scrubbing is
+  already a uniform sink concern (ADR-0005, ADR-0007), not a reason to blind the
+  audit line. Isolation would also make audit Context behave oppositely to every
+  other line for no caller-visible reason.
+- **Audit Context left unguarded** (rejected) - "emit the audit event whole or
+  fail loudly" rather than let the guard drop/substitute. Rejected: a malformed
+  line in WORM storage is the worse outcome, and the guard already diagnoses
+  loudly what it drops; uniform behaviour beats a bespoke audit exception.
+- **Audit module owns merge + guard (option A)** (rejected) - exposing scope and
+  the guard to the audit module duplicates the guard call and breaks the
+  "layers above the base, never touches pino" charter from ADR-0007.
+
+## Consequences
+
+- Audit lines now carry the logger's scoped Context, merged beneath event and
+  per-call Context, matching routine lines. Existing callers that relied on
+  scoped Context being *absent* from audit lines (there should be none - it was a
+  silent drop, not a documented contract) would see those keys appear.
+- The Context guard applies to audit Context. An oversized/unserialisable audit
+  Context is dropped-and-diagnosed like any other, instead of producing a
+  malformed line in retention storage.
+- The audit module is unchanged in charter: pure event assembly, no pino, no
+  guard. The merge + guard live in `LoggerImpl`'s injected `emit`.
+- ADR-0007's glossary entry for **Audit event** is sharpened: "fixed and
+  enforced" means the *required* fields are guaranteed, not that the Context bag
+  is closed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,4 +16,5 @@ Files are numbered sequentially: `NNNN-kebab-case-title.md`.
 | [0004](./0004-scope-not-pino-child.md)          | Scoping is `scope`, not `child`              | Accepted |
 | [0005](./0005-no-redaction-in-base-logger.md)   | No redaction in the base logger              | Accepted |
 | [0006](./0006-pluggable-error-serialization.md) | Pluggable error serialisation; no error type | Accepted |
-| [0007](./0007-fixed-shape-audit-helpers.md)     | Fixed-shape audit helpers                    | Accepted |
+| [0007](./0007-fixed-shape-audit-helpers.md)     | Fixed-shape audit helpers                    | Accepted (amended by [0008](./0008-audit-lines-compose-scoped-context.md)) |
+| [0008](./0008-audit-lines-compose-scoped-context.md) | Audit lines compose scoped context      | Accepted |

--- a/packages/logging/CONTEXT.md
+++ b/packages/logging/CONTEXT.md
@@ -30,8 +30,12 @@ _Avoid_: sanitiser, validator, limiter
 A compliance-auditable business event — "who did what to which critical
 resource" — drawn from a **closed, externally-governed taxonomy**
 (authentication, permission change, data export, …), not from developer
-convenience. Unlike a routine log line, its **Context** shape is _fixed and
-enforced_, and it is the unit that redaction and audit-retention apply to.
+convenience. Unlike a routine log line, its _required_ **Context** fields are
+fixed and enforced at the type level; beyond those, the logger's scoped
+**Context** and per-call **Context** merge in (low→high: scoped, event fields,
+per-call) and pass the same **Context guard** as any line. "Enforced" means the
+required keys are guaranteed, not that the bag is closed. It is the unit that
+redaction and audit-retention apply to.
 _Avoid_: audit log (ambiguous with the log store), event (too broad)
 
 **Audit helper**:

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -392,6 +392,62 @@ describe('audit.failures', () => {
   })
 })
 
+describe('audit context composition (ADR-0008)', () => {
+  const reqLogger = () =>
+    createBaseLogger({ traceId: null, path: '/data', clientIp: '1.2.3.4', userAgent: 'jest', userId: 'u_1' })
+
+  it('merges the logger scoped context into the audit line', () => {
+    reqLogger()
+      .scope({ action: 'readRecord', context: { tenant_id: 't_1' } })
+      .audit.dataAccess.dataAccessed({
+        resourceType: 'citizen_record',
+        resourceId: 'r_1',
+        accessType: 'read',
+        classification: 'confidential',
+      })
+    // tenant_id came from scope; event fields ride alongside it.
+    expect(at(0).context).toMatchObject({
+      tenant_id: 't_1',
+      resource_type: 'citizen_record',
+      resource_id: 'r_1',
+    })
+  })
+
+  it('merges context set after the audit namespace is accessed (call-time read)', () => {
+    const log = reqLogger().scope({ action: 'readRecord', context: { a: 1 } })
+    void log.audit // memoise the namespace first
+    log.setContext({ context: { b: 2 } })
+    log.audit.dataAccess.dataAccessed({ resourceType: 't', resourceId: 'r', accessType: 'read', classification: 'pii' })
+    expect(at(0).context).toMatchObject({ a: 1, b: 2 })
+  })
+
+  it('lets a per-call context key override a scoped one (more specific wins)', () => {
+    reqLogger()
+      .scope({ action: 'readRecord', context: { classification: 'public' } })
+      .audit.dataAccess.dataAccessed({
+        resourceType: 't',
+        resourceId: 'r',
+        accessType: 'read',
+        classification: 'restricted',
+      })
+    // event/per-call field wins over the ambient scoped key of the same name.
+    expect((at(0).context as Record<string, unknown>).classification).toBe('restricted')
+  })
+
+  it('runs the Context guard over the merged audit context', () => {
+    reqLogger()
+      .scope({ action: 'readRecord', context: { huge: 'x'.repeat(200_001) } })
+      .audit.dataAccess.dataAccessed({ resourceType: 't', resourceId: 'r', accessType: 'read', classification: 'pii' })
+
+    const lines = entries()
+    // The guard drops the oversized bag and diagnoses it, then the event line
+    // carries the marker instead of a malformed context.
+    expect(lines.some(l => l.message === 'Log context is too large')).toBe(true)
+    const event = lines.find(l => l.event === 'dataAccessed')
+    expect(event?.context).toEqual({ logger: '[Context removed]' })
+  })
+})
+
 describe('audit.resource', () => {
   const reqLogger = () =>
     createBaseLogger({ traceId: null, path: '/forms', clientIp: '1.2.3.4', userAgent: 'jest', userId: 'u_1' })

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -301,7 +301,13 @@ class LoggerImpl implements Logger {
     return (this._audit ??= createAuditLogger({
       bindings: () => this.logger.bindings(),
       emit: (level, fields, message) => {
-        this.logger[level](fields, message)
+        // Pull the audit-assembled context out, merge the logger's scoped
+        // context beneath it, and run the same guard the routine path uses
+        // (ADR-0008). `emitAudit` stays ignorant of scope, pino, and the guard;
+        // controlled fields + promoted facets in `rest` pass straight through.
+        const { context: ownContext, ...rest } = fields
+        const context = this.guardContext(rest.action as string | undefined, ownContext as LogInput['context'])
+        this.logger[level]({ ...rest, context }, message)
       },
       action: () => this.action ?? undefined,
     }))
@@ -352,18 +358,25 @@ class LoggerImpl implements Logger {
     // Per-call action wins over the scoped leaf; omitted entirely when neither is
     // set (the `action` key is then absent from the line, not `''`).
     const action = input.action ?? this.action ?? undefined
+    const context = this.guardContext(action, input.context)
+    return { ...input, action, context }
+  }
 
-    const merged = mergeContext(this.context, input.context) ?? undefined
-
-    // The Context guard owns oversized/unserialisable handling; we just attach
-    // scope to its diagnostic lines and emit them. These bypass formatInput
-    // (they go straight to the transport), so the guard never recurses.
+  /**
+   * Merge the logger's scoped context beneath the line's own context, run it
+   * through the Context guard, and emit the guard's diagnostic lines (attaching
+   * `action`). Returns the safe context to attach. Shared by the routine path
+   * ({@link formatInput}) and the audit `emit` closure (ADR-0008), so scoped
+   * context and the guard apply identically to both. The diagnostic lines bypass
+   * this method (they go straight to the transport), so the guard never recurses.
+   */
+  private guardContext(action: string | undefined, ownContext: LogInput['context']): LogInput['context'] {
+    const merged = mergeContext(this.context, ownContext) ?? undefined
     const { context, emissions } = serializeContext(merged)
     for (const emission of emissions) {
       this.logger[emission.level]({ action, context: emission.context }, emission.message)
     }
-
-    return { ...input, action, context }
+    return context
   }
 }
 


### PR DESCRIPTION
## Problem

`logger.scope({ context }).audit.*({ context })` silently **dropped** the scoped context. The audit `emit` closure wrote fields straight to the pino child, bypassing the context tail the routine log path uses. So `scope({ context: { a } }).audit.x({ context: { b } })` emitted only `{ b }` (plus event fields) - the ambient `{ a }` an auditor most wants on a "who did what" line vanished.

## Fix

Extract the merge + guard + diagnostics tail into one private `guardContext()`, used by **both** the routine path (`formatInput`) and the audit `emit` closure (option B). The audit module stays pure assembly - no pino, no guard, charter from ADR-0007 preserved.

- **Merge precedence** (low to high): scoped context, event `contextFields`, per-call `context`. Mirrors the routine path; more-specific wins.
- **Context guard** now runs uniformly over the merged audit context - an oversized/unserialisable bag is dropped-and-diagnosed instead of producing a malformed line in WORM/retention storage.
- Scoped context is read at call time (closure over `this`), so `setContext` after `.audit` access is tracked.

## Docs

- New **ADR-0008** (amends ADR-0007); 0007 status + README index updated.
- `CONTEXT.md` "Audit event" glossary sharpened: "fixed and enforced" means *required fields* guaranteed, not a closed bag.

## Tests

+4 regression tests (scope merge, call-time read, per-call override, guard over merged context). Full package suite 79 pass; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)