### PR TITLE
feat(logging): require userId on session audit helpers

### DIFF
--- a/.changeset/session-audit-user-id.md
+++ b/.changeset/session-audit-user-id.md
@@ -1,0 +1,14 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Promote `userId` to the canonical `user_id` facet on `sessionCreated` and
+`sessionTerminated`, aligning them with their sibling `sessionTimedOut`. These
+session events establish or operate on the bound identity, so `user_id` cannot
+be assumed present in request scope: `sessionCreated` is the very call that
+binds it, and termination may run outside a request (admin revoke, sweep).
+Identity is therefore payload-borne - `userId` is now a required input field,
+promoted to `user_id`, and only `client_ip` is required in scope.
+
+Breaking for existing callers: `sessionCreated` and `sessionTerminated` now
+require a `userId` argument.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -314,12 +314,14 @@ export function serializeError(err: Error): Record<string, unknown>;
 // @public
 export interface SessionCreatedInput extends AuditInputBase {
     sessionId: string;
+    userId: string;
 }
 
 // @public
 export interface SessionTerminatedInput extends AuditInputBase {
     reason: string;
     sessionId: string;
+    userId: string;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -286,8 +286,8 @@ the per-event tables below.
 | ------------------- | -------- | ---------------------------------------------------------------------------- |
 | `loginSucceeded`    | `notice` | `userId`, `role`, `privileged` _(opt: `username`, `sessionId`)_              |
 | `loginFailed`       | `notice` | `username`, `reason`, `attemptCount`, `privileged` _(opt: `userId`, `role`)_ |
-| `sessionCreated`    | `notice` | `sessionId`                                                                  |
-| `sessionTerminated` | `notice` | `sessionId`, `reason`                                                        |
+| `sessionCreated`    | `notice` | `userId`, `sessionId`                                                        |
+| `sessionTerminated` | `notice` | `userId`, `sessionId`, `reason`                                              |
 | `sessionTimedOut`   | `notice` | `userId`, `sessionId`                                                        |
 | `tokenReused`       | `warn`   | `tokenId` _(opt: `sessionId`)_                                               |
 

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -63,15 +63,19 @@ export const AUTHN_SPECS = {
   sessionCreated: authn('sessionCreated', {
     level: 'notice',
     message: 'Session created',
-    promote: {},
-    requiredScope: ['user_id', 'client_ip'],
+    promote: { userId: 'user_id' },
+    // sessionCreated establishes the bound identity, so user_id cannot already be
+    // in request scope when it fires; it is payload-borne, like sessionTimedOut.
+    requiredScope: ['client_ip'],
     contextFields: { sessionId: 'session_id' },
   }),
   sessionTerminated: authn('sessionTerminated', {
     level: 'notice',
     message: 'Session terminated',
-    promote: {},
-    requiredScope: ['user_id', 'client_ip'],
+    promote: { userId: 'user_id' },
+    // Like the other session events, identity is payload-borne: termination may run
+    // outside request scope (admin revoke, sweep), so do not require it in scope.
+    requiredScope: ['client_ip'],
     contextFields: { sessionId: 'session_id', reason: 'reason' },
   }),
   sessionTimedOut: authn('sessionTimedOut', {

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -107,12 +107,16 @@ export interface LoginFailedInput extends AuditInputBase {
 
 /** Input for {@link AuthnAudit.sessionCreated}. @public */
 export interface SessionCreatedInput extends AuditInputBase {
+  /** The session owner. Promoted to `user_id` (the session being created is what would bind it to scope). */
+  userId: string
   /** Session identifier (a non-impersonatable reference, not the bearer token). */
   sessionId: string
 }
 
 /** Input for {@link AuthnAudit.sessionTerminated}. @public */
 export interface SessionTerminatedInput extends AuditInputBase {
+  /** The session owner. Promoted to `user_id` (termination may run outside request scope). */
+  userId: string
   /** The session being ended (a reference, not the bearer token). */
   sessionId: string
   /** Why the session ended, e.g. `logout`, `revoked`. */


### PR DESCRIPTION
## What

Promote `userId` to the canonical `user_id` facet on the `sessionCreated` and `sessionTerminated` audit helpers, aligning them with their sibling `sessionTimedOut`.

| Event | Before | After |
| --- | --- | --- |
| `sessionCreated` | `requiredScope: ['user_id', 'client_ip']`, no `userId` input | `promote: { userId }`, `requiredScope: ['client_ip']`, required `userId` input |
| `sessionTerminated` | `requiredScope: ['user_id', 'client_ip']`, no `userId` input | `promote: { userId }`, `requiredScope: ['client_ip']`, required `userId` input |

## Why

These session events establish or operate on the bound identity, so `user_id` cannot be assumed present in request scope:

- `sessionCreated` is the very call that binds the identity (chicken-and-egg: the session that would put `user_id` in scope is the one being created).
- `sessionTerminated` may run outside a request (admin revoke, timeout sweep).

This is the same reasoning already spelled out for `sessionTimedOut` ("a timeout sweep may run with no request scope, so identity is payload-borne"). The three session events now share one shape: identity is payload-borne via `userId`, only `client_ip` is required in scope.

`userId` is kept **required** (not optional): a session is minted *for* a principal, so the caller always knows who. Optional `userId` is the `loginFailed` / `accessDenied` pattern, reserved for genuinely-unknown identity, which can't apply at session creation.

## Breaking change

`sessionCreated` and `sessionTerminated` now require a `userId` argument. Captured as a `minor` changeset (pre-1.0).

## Checks

- `tsc` build clean, API report regenerated (`etc/starter-kitty-logging.api.md`)
- 79 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)