### PR TITLE
feat(logging): add Logger.withBindings to bind actor mid-request

### DIFF
--- a/.changeset/logger-with-bindings.md
+++ b/.changeset/logger-with-bindings.md
@@ -2,6 +2,8 @@
 '@opengovsg/starter-kitty-logging': minor
 ---
 
-Add `Logger.withBindings({ userId })` to bind the acting user at the root of an
-existing logger - for identity learned mid-request (e.g. self-signup), so
-actor-scoped audit events attribute the actor instead of warning.
+Add `Logger.withBindings({ userId })` and `Logger.setBindings({ userId })` to
+bind the acting user at the root of an existing logger - for identity learned
+mid-request (e.g. self-signup), so actor-scoped audit events attribute the
+actor instead of warning. `withBindings` returns a new logger; `setBindings`
+mutates in place, so the actor persists for the rest of the logger's lifecycle.

--- a/.changeset/logger-with-bindings.md
+++ b/.changeset/logger-with-bindings.md
@@ -1,0 +1,7 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Add `Logger.withBindings({ userId })` to bind the acting user at the root of an
+existing logger - for identity learned mid-request (e.g. self-signup), so
+actor-scoped audit events attribute the actor instead of warning.

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -150,6 +150,9 @@ export interface Logger {
         context: LogInput['context'];
     }): Logger;
     warn(input: LogInput): void;
+    withBindings(bindings: {
+        userId?: string;
+    }): Logger;
     withContext(options: {
         context: LogInput['context'];
     }): Logger;

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -146,6 +146,9 @@ export interface Logger {
     setAction(options: {
         action: string;
     }): Logger;
+    setBindings(bindings: {
+        userId?: string;
+    }): Logger;
     setContext(options: {
         context: LogInput['context'];
     }): Logger;

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -148,6 +148,11 @@ scoped.info({ message: 'saving' })
   request scoping). Unlike `pino.child`, it **merges** context rather than
   replacing it — the real pino child is `createBaseLogger`.
 - `withContext({ context })` — returns a **new** logger with merged context.
+- `withBindings({ userId })` — returns a **new** logger with the acting user
+  bound at the **root** (`user_id`), for identity learned mid-request. Unlike
+  `withContext`, this lands at the top level, so actor-scoped audit events find
+  it. Request-fixed facets (`client_ip`, `user_agent`, `path`) are inherited
+  untouched.
 - `setAction({ action })` / `setContext({ context })` — mutate **in place** and
   return the same instance for chaining.
 
@@ -270,7 +275,9 @@ logger.scope({ action: 'verifyOtp' }).audit.authn.loginSucceeded({
   `username`, …) stay raw and are scrubbed at the **sink**, not in-process.
 - **Scope-read fields are asserted at emit:** when an event reads `user_id` /
   `client_ip` from the scope and it is missing, the helper emits a loud
-  diagnostic line rather than a silently-incomplete audit record.
+  diagnostic line rather than a silently-incomplete audit record. Identity
+  learned after creation (e.g. the acting user on self-signup) is bound with
+  `withBindings({ userId })` so actor-scoped events attribute the actor.
 
 See [ADR-0007](../../docs/adr/0007-fixed-shape-audit-helpers.md) for the design.
 Every input additionally accepts `context?` (extra business fields, merged into

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -153,13 +153,17 @@ scoped.info({ message: 'saving' })
   `withContext`, this lands at the top level, so actor-scoped audit events find
   it. Request-fixed facets (`client_ip`, `user_agent`, `path`) are inherited
   untouched.
-- `setAction({ action })` / `setContext({ context })` — mutate **in place** and
-  return the same instance for chaining.
+- `setAction({ action })` / `setContext({ context })` / `setBindings({ userId })`
+  — mutate **in place** and return the same instance for chaining. `setBindings`
+  is the mutating twin of `withBindings`: the bound `user_id` persists for the
+  rest of the logger's lifecycle.
 
-**⚠️ Caveat:** `setAction` / `setContext` mutate the logger in place. If you
-share a logger across concurrent requests (e.g. a module-level singleton), the
-scope/context bleeds between them. Prefer `scope` / `withContext` for
-request-scoped work.
+**⚠️ Caveat:** `setAction` / `setContext` / `setBindings` mutate the logger in
+place. If you share a logger across concurrent requests (e.g. a module-level
+singleton), the scope/context bleeds between them. Prefer `scope` /
+`withContext` for request-scoped work. For `setBindings` the stakes are higher:
+a bled `user_id` **misattributes audit events** to the wrong user - only ever
+call it on a per-request logger.
 
 ## Choosing a level
 

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -488,3 +488,32 @@ describe('audit.resource', () => {
     expect(line).not.toHaveProperty('from_owner_id') // from/to live in context, not root
   })
 })
+
+describe('withBindings', () => {
+  it('binds a late-known actor so actor-scoped events do not warn', () => {
+    createBaseLogger({ traceId: null, path: '/signup', clientIp: '1.2.3.4', userAgent: 'jest' })
+      .withBindings({ userId: 'u_new' })
+      .scope({ action: 'team:create' })
+      .audit.resource.created({ resourceType: 'team', resourceId: 't_1' })
+
+    // No "missing required scope" diagnostic ...
+    expect(entries().find(l => l.message === 'Audit event missing required scope field')).toBeUndefined()
+    // ... the actor is on the event line at the root, and the request-fixed
+    // facet (client_ip) is inherited untouched by the rebind.
+    expect(entries().find(l => l.event === 'created')).toMatchObject({
+      user_id: 'u_new',
+      client_ip: '1.2.3.4',
+      context: { resource_type: 'team', resource_id: 't_1' },
+    })
+  })
+
+  it('returns a new logger and leaves the original unbound', () => {
+    const base = createBaseLogger({ traceId: null, path: '/signup', clientIp: '1.2.3.4', userAgent: 'jest' })
+    base.withBindings({ userId: 'u_new' }) // discarded
+    base.scope({ action: 'team:create' }).audit.resource.created({ resourceType: 'team', resourceId: 't_2' })
+
+    expect(entries().find(l => l.message === 'Audit event missing required scope field')).toMatchObject({
+      context: { missing_scope: ['user_id'] },
+    })
+  })
+})

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -517,3 +517,21 @@ describe('withBindings', () => {
     })
   })
 })
+
+describe('setBindings', () => {
+  it('binds the actor in place so it persists on the same logger', () => {
+    const base = createBaseLogger({ traceId: null, path: '/signup', clientIp: '1.2.3.4', userAgent: 'jest' })
+    const returned = base.setBindings({ userId: 'u_new' }) // mutates, not discarded
+    expect(returned).toBe(base) // same instance, for chaining
+
+    // The original reference now carries the actor - no reassignment needed.
+    base.scope({ action: 'team:create' }).audit.resource.created({ resourceType: 'team', resourceId: 't_1' })
+
+    expect(entries().find(l => l.message === 'Audit event missing required scope field')).toBeUndefined()
+    expect(entries().find(l => l.event === 'created')).toMatchObject({
+      user_id: 'u_new',
+      client_ip: '1.2.3.4', // request-fixed facet inherited untouched
+      context: { resource_type: 'team', resource_id: 't_1' },
+    })
+  })
+})

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -1,4 +1,4 @@
-import type { DestinationStream } from 'pino'
+import type { DestinationStream, Logger as PinoLogger } from 'pino'
 import { destination, pino } from 'pino'
 import { PinoPretty } from 'pino-pretty'
 
@@ -120,6 +120,16 @@ export interface LoggerOptions extends SystemLoggerOptions {
 type AnyLoggerOptions = SystemLoggerOptions & { clientIp?: string | null; userAgent?: string | null }
 
 /**
+ * The root-level identity {@link Logger.withBindings} can bind on an existing
+ * logger. Deliberately narrow: only the acting user, which may be learned
+ * *after* creation. Request-fixed facets (`client_ip`, `user_agent`, `path`,
+ * versions) are set once at creation and inherited untouched. Module-local: the
+ * public {@link Logger.withBindings} inlines this shape to avoid a `types.ts`
+ * import of `logger.ts` (a cycle).
+ */
+type LateBindings = Pick<SystemLoggerOptions, 'userId'>
+
+/**
  * A {@link Logger} factory bound to a fixed {@link LoggingConfig}, returned by
  * {@link createLogging}. Call it directly for a **request** logger (client
  * identity required via {@link LoggerOptions}); call `.system(...)` for a
@@ -190,14 +200,20 @@ const buildPino = (config: ResolvedConfig) => {
   )
 }
 
-type PinoInstance = ReturnType<typeof buildPino>
+/**
+ * The root instance or any child of it — what `bindChild` accepts. A child
+ * widens `useOnlyCustomLevels` from the root's `true` to `boolean`, so this
+ * (`boolean`) covers both: the root binds at creation, `withBindings` re-binds
+ * onto an existing child.
+ */
+type PinoChild = PinoLogger<'error' | 'warn' | 'notice' | 'info' | 'debug', boolean>
 
 /*
   The child loggers we hand out inherit the bindings and transport from the
   parent instance. Use child loggers to avoid creating a new pino instance for
   every request / unit of work.
 */
-const bindChild = (instance: PinoInstance, options: AnyLoggerOptions) => {
+const bindChild = (instance: PinoChild, options: Partial<AnyLoggerOptions>) => {
   const { source, path, traceId, userId, deviceId, userAgent, correlationId, clientIp, clientVersion, serverVersion } =
     options
   // Coalesce `null` -> `undefined` on the header-sourced fields (`headers.get`
@@ -284,6 +300,20 @@ class LoggerImpl implements Logger {
     return new LoggerImpl(this.logger, this.serializeError, {
       action: this.action,
       context: mergeContext(this.context, options.context),
+    })
+  }
+
+  withBindings(bindings: LateBindings) {
+    // Root-level facet, not context: a fresh pino child inherits the parent's
+    // bindings and merges these on top, so audit scope-read asserts (e.g.
+    // `user_id`) see it. `bindChild` maps only the fields present, so
+    // `client_ip`/`user_agent`/`path` are inherited untouched. For identity
+    // learned mid-request (the acting user is known only after login), unlike
+    // `withContext` which lands in `context`. Action and context carry over
+    // unchanged, matching `scope`/`withContext` immutability.
+    return new LoggerImpl(bindChild(this.logger, bindings), this.serializeError, {
+      action: this.action,
+      context: this.context,
     })
   }
 

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -317,6 +317,15 @@ class LoggerImpl implements Logger {
     })
   }
 
+  setBindings(bindings: LateBindings) {
+    // The mutating twin of `withBindings`: swap in a child that merges the new
+    // root facets, so it persists for the rest of this logger's lifecycle. The
+    // audit closure and routine path both read `this.logger` at call time, so
+    // every subsequent line picks the rebinding up.
+    this.logger = bindChild(this.logger, bindings)
+    return this
+  }
+
   setContext(options: { context: LogInput['context'] }) {
     this.context = mergeContext(this.context, options.context)
     return this

--- a/packages/logging/src/types.ts
+++ b/packages/logging/src/types.ts
@@ -95,6 +95,21 @@ export interface Logger {
   withContext(options: { context: LogInput['context'] }): Logger
 
   /**
+   * Return a **new** logger that binds the acting user at the **root level**
+   * (`user_id`), leaving the original unchanged. Unlike {@link Logger.withContext}
+   * (which lands in `context`), `user_id` is a top-level field and so satisfies
+   * the audit scope-read asserts - e.g. binding the acting user once it is known
+   * mid-request (self-signup, deferred auth), so `audit.resource.*` and other
+   * actor-scoped events attribute the actor instead of warning. Request-fixed
+   * facets (`client_ip`, `user_agent`, `path`) are set at creation and inherited
+   * untouched.
+   *
+   * @param bindings - Root-level identity learned after creation.
+   * @returns A new {@link Logger} with `user_id` bound at the root.
+   */
+  withBindings(bindings: { userId?: string }): Logger
+
+  /**
    * Verbose diagnostic detail useful only while actively debugging (e.g.
    * branch traces, intermediate values). Typically disabled in production.
    * No one is expected to act on it.

--- a/packages/logging/src/types.ts
+++ b/packages/logging/src/types.ts
@@ -110,6 +110,23 @@ export interface Logger {
   withBindings(bindings: { userId?: string }): Logger
 
   /**
+   * Bind the acting user at the **root level** (`user_id`) **in place**
+   * (mutates), so it persists for the rest of this logger's lifecycle - every
+   * subsequent line, audit and routine, attributes the actor. The mutating twin
+   * of {@link Logger.withBindings}, for the common case where one request logger
+   * is threaded by reference and gains its identity mid-request.
+   *
+   * ⚠️ Mutation is shared: see the caveat on {@link Logger.setAction}. Here the
+   * stakes are higher - if a logger is reused across requests (e.g. a
+   * module-level singleton), a bound `user_id` bleeds into other users' lines,
+   * **misattributing audit events**. Only ever call this on a per-request logger.
+   *
+   * @param bindings - Root-level identity learned after creation.
+   * @returns The same logger instance, for chaining.
+   */
+  setBindings(bindings: { userId?: string }): Logger
+
+  /**
    * Verbose diagnostic detail useful only while actively debugging (e.g.
    * branch traces, intermediate values). Typically disabled in production.
    * No one is expected to act on it.


### PR DESCRIPTION
## Why

Actor-scoped audit events (`audit.resource.*`, and others whose spec lists `user_id` in `requiredScope`) warn `"Audit event missing required scope field"` when the acting user isn't bound in request scope. This happens on **first-login default-team creation**: on self-signup the acting user's id only exists after the login upsert, so the request logger was created with no `user_id` bound.

`scope()` / `withContext()` only touch the leaf action and the `context` bag - neither can add a **root-level** facet, so there was no way to bind `user_id` once it became known without rebuilding a logger from headers (which also discards accumulated action/context).

## What

Adds a root-level identity binding for an existing logger, in both flavours - completing the immutable + mutating pair the library already has for `scope`/`setAction` and `withContext`/`setContext`:

- **`withBindings({ userId })`** - returns a **new** logger with `user_id` bound at the root.
- **`setBindings({ userId })`** - binds **in place**, so the actor persists for the rest of the logger's lifecycle. This is the common case: one request logger is threaded by reference (e.g. `ctx.logger`) and gains its identity mid-request, and every downstream holder should see it without reassigning.

Request-fixed facets (`client_ip`, `user_agent`, `path`) are inherited untouched - only `user_id` is added. Binding once attributes the actor on **every** subsequent line (audit + routine), which is why this is the right primitive rather than relaxing a spec's `requiredScope`.

Surface is deliberately narrow (one facet) - only what a real caller needs today; widening later is a non-breaking additive change.

### Implementation notes

- Both share the existing `bindChild` (the `null`/`undefined`-omission it relies on is already load-bearing in production and test-covered). `setBindings` swaps in `this.logger = bindChild(this.logger, bindings)`; the audit closure and routine path both read `this.logger` at call time, so the rebinding propagates.
- `bindChild` is loosened to a `Partial` input (it is a merge-subset helper) and its param type now covers both the root instance and a child logger (`useOnlyCustomLevels` widens `true` -> `boolean` on children). Both were latent type errors that only surface under `tsc`.

### Caveat

`setBindings` mutates in place, so - like the other `set*` methods - a logger shared across concurrent requests bleeds state. For `user_id` the stakes are higher: a bled id **misattributes audit events** to the wrong user. Documented loudly; only ever call on a per-request logger.

## Verification

`tsc` build, lint, 82 tests (incl. `withBindings` late-actor + immutability, and `setBindings` in-place persistence, each asserting `client_ip` is inherited untouched), format, and api-extractor all pass.

## Downstream (out of scope here)

Confetti currently runs this via a pnpm patch; after release it bumps the dep and drops the patch. No app-repo changes live in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)