### PR TITLE
feat(logging): make apiUsage userId optional, require keyId principal

### DIFF
--- a/.changeset/api-usage-optional-user-id.md
+++ b/.changeset/api-usage-optional-user-id.md
@@ -1,0 +1,18 @@
+---
+'@opengovsg/starter-kitty-logging': minor
+---
+
+Make `userId` optional across the `apiUsage` audit group. These events run on
+machine/bearer-token requests that often have no authenticated user, so
+requiring `user_id` in scope emitted a spurious "missing required scope field"
+diagnostic. `user_id` is now optional throughout - dropped from `requiredScope`
+and promoted from the payload only when supplied (for a user-bound key).
+
+Each event still carries a required non-user principal so no API-usage line is
+anonymous: `tokenId` on the token lifecycle events, and a new required `keyId`
+(the API credential id, emitted as `context.key_id`) on
+`sensitiveEndpointAccessed`.
+
+Breaking for existing callers: `sensitiveEndpointAccessed` now requires a
+`keyId` argument. `tokenIssued`'s `userId` changes from required to optional
+(a safe widening).

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -310,8 +310,10 @@ export interface SensitiveActionBlockedInput extends AuditInputBase {
 // @public
 export interface SensitiveEndpointAccessedInput extends AuditInputBase {
     endpoint: string;
+    keyId: string;
     method: string;
     params?: AuditContext;
+    userId?: string;
 }
 
 // @public
@@ -352,18 +354,20 @@ export interface SystemLoggerOptions {
 export interface TokenInvalidatedInput extends AuditInputBase {
     reason: string;
     tokenId: string;
+    userId?: string;
 }
 
 // @public
 export interface TokenIssuedInput extends AuditInputBase {
     scopes?: string[];
     tokenId: string;
-    userId: string;
+    userId?: string;
 }
 
 // @public
 export interface TokenRefreshedInput extends AuditInputBase {
     tokenId: string;
+    userId?: string;
 }
 
 // @public

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -352,11 +352,11 @@ user, so `userId` is optional throughout — supply it only for a user-bound key
 Each event still carries a required non-user principal (`tokenId` or `keyId`), so
 no line is anonymous.
 
-| Event                       | Level    | Required fields                                     |
-| --------------------------- | -------- | --------------------------------------------------- |
-| `tokenIssued`               | `notice` | `tokenId` _(opt: `userId`, `scopes`)_               |
-| `tokenRefreshed`            | `notice` | `tokenId` _(opt: `userId`)_                         |
-| `tokenInvalidated`          | `notice` | `tokenId`, `reason` _(opt: `userId`)_               |
+| Event                       | Level    | Required fields                                           |
+| --------------------------- | -------- | --------------------------------------------------------- |
+| `tokenIssued`               | `notice` | `tokenId` _(opt: `userId`, `scopes`)_                     |
+| `tokenRefreshed`            | `notice` | `tokenId` _(opt: `userId`)_                               |
+| `tokenInvalidated`          | `notice` | `tokenId`, `reason` _(opt: `userId`)_                     |
 | `sensitiveEndpointAccessed` | `notice` | `endpoint`, `method`, `keyId` _(opt: `userId`, `params`)_ |
 
 #### `failures` — handled security denials

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -347,12 +347,17 @@ secrets.
 Anomaly/abuse detection is intentionally absent — the app does not know a call is
 anomalous at log time; that is a sink/SIEM concern _over_ these lines.
 
-| Event                       | Level    | Required fields                        |
-| --------------------------- | -------- | -------------------------------------- |
-| `tokenIssued`               | `notice` | `userId`, `tokenId` _(opt: `scopes`)_  |
-| `tokenRefreshed`            | `notice` | `tokenId`                              |
-| `tokenInvalidated`          | `notice` | `tokenId`, `reason`                    |
-| `sensitiveEndpointAccessed` | `notice` | `endpoint`, `method` _(opt: `params`)_ |
+API usage runs on machine/bearer-token requests that often have no authenticated
+user, so `userId` is optional throughout — supply it only for a user-bound key.
+Each event still carries a required non-user principal (`tokenId` or `keyId`), so
+no line is anonymous.
+
+| Event                       | Level    | Required fields                                     |
+| --------------------------- | -------- | --------------------------------------------------- |
+| `tokenIssued`               | `notice` | `tokenId` _(opt: `userId`, `scopes`)_               |
+| `tokenRefreshed`            | `notice` | `tokenId` _(opt: `userId`)_                         |
+| `tokenInvalidated`          | `notice` | `tokenId`, `reason` _(opt: `userId`)_               |
+| `sensitiveEndpointAccessed` | `notice` | `endpoint`, `method`, `keyId` _(opt: `userId`, `params`)_ |
 
 #### `failures` — handled security denials
 

--- a/packages/logging/src/__tests__/audit.test.ts
+++ b/packages/logging/src/__tests__/audit.test.ts
@@ -341,9 +341,27 @@ describe('audit.apiUsage', () => {
     }).audit.apiUsage.sensitiveEndpointAccessed({
       endpoint: '/api/admin/export',
       method: 'POST',
+      keyId: 'key_1',
       params: { scope: 'all' },
     })
-    expect(at(0).context).toMatchObject({ endpoint: '/api/admin/export', method: 'POST', params: { scope: 'all' } })
+    expect(at(0).context).toMatchObject({
+      endpoint: '/api/admin/export',
+      method: 'POST',
+      key_id: 'key_1',
+      params: { scope: 'all' },
+    })
+  })
+
+  it('emits no missing-scope diagnostic for a bearer-token request without user_id', () => {
+    createBaseLogger({
+      traceId: null,
+      path: '/api',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest',
+    }).audit.apiUsage.tokenRefreshed({ tokenId: 'tok_1' })
+    const lines = entries()
+    expect(lines).toHaveLength(1) // user_id not required for API usage
+    expect(lines[0]).not.toHaveProperty('user_id')
   })
 })
 

--- a/packages/logging/src/audit/spec.ts
+++ b/packages/logging/src/audit/spec.ts
@@ -248,8 +248,9 @@ const apiUsage = (event: string, spec: Omit<EventSpec, 'category' | 'event'>): E
   ...spec,
 })
 
-// `tokenIssued` *produces* the subject, so `userId` is payload-required and
-// promoted; the others run in an authenticated context (`user_id` scope-read).
+// API usage runs on machine/bearer-token requests that often have no
+// authenticated `user_id` in scope, so `user_id` is never required here — it is
+// an optional payload field, promoted when the caller has a user-bound token.
 /** API usage event specs. */
 export const API_USAGE_SPECS = {
   tokenIssued: apiUsage('tokenIssued', {
@@ -262,23 +263,25 @@ export const API_USAGE_SPECS = {
   tokenRefreshed: apiUsage('tokenRefreshed', {
     level: 'notice',
     message: 'API token refreshed',
-    promote: {},
-    requiredScope: ['user_id', 'client_ip'],
+    promote: { userId: 'user_id' },
+    requiredScope: ['client_ip'],
     contextFields: { tokenId: 'token_id' },
   }),
   tokenInvalidated: apiUsage('tokenInvalidated', {
     level: 'notice',
     message: 'API token invalidated',
-    promote: {},
-    requiredScope: ['user_id', 'client_ip'],
+    promote: { userId: 'user_id' },
+    requiredScope: ['client_ip'],
     contextFields: { tokenId: 'token_id', reason: 'reason' },
   }),
   sensitiveEndpointAccessed: apiUsage('sensitiveEndpointAccessed', {
     level: 'notice',
     message: 'Sensitive endpoint accessed',
-    promote: {},
-    requiredScope: ['user_id', 'client_ip'],
-    contextFields: { endpoint: 'endpoint', method: 'method', params: 'params' },
+    promote: { userId: 'user_id' },
+    requiredScope: ['client_ip'],
+    // `keyId` is the required principal (compile-time enforced) so the line is
+    // never anonymous; `user_id` is optional for user-bound keys.
+    contextFields: { endpoint: 'endpoint', method: 'method', keyId: 'key_id', params: 'params' },
   }),
 } satisfies Record<string, EventSpec>
 

--- a/packages/logging/src/audit/types.ts
+++ b/packages/logging/src/audit/types.ts
@@ -336,9 +336,12 @@ export interface PolicyChangedInput extends AuditInputBase {
 /**
  * API usage audit events (category `apiUsage`).
  *
- * Covers API token lifecycle and access to sensitive endpoints. Anomaly/abuse
- * detection is intentionally absent — the app does not know a call is anomalous
- * at log time; that is a sink/SIEM concern *over* these lines (ADR-0007).
+ * Covers API token lifecycle and access to sensitive endpoints. These run on
+ * machine/bearer-token requests that often have no authenticated user, so
+ * `userId` is optional throughout — supply it only when the token is user-bound.
+ * Anomaly/abuse detection is intentionally absent — the app does not know a call
+ * is anomalous at log time; that is a sink/SIEM concern *over* these lines
+ * (ADR-0007).
  *
  * @public
  */
@@ -355,10 +358,10 @@ export interface ApiUsageAudit {
 
 /** Input for {@link ApiUsageAudit.tokenIssued}. @public */
 export interface TokenIssuedInput extends AuditInputBase {
-  /** The subject the token was issued for. Promoted to `user_id`. */
-  userId: string
   /** The token's identifier — a reference, never the token value. */
   tokenId: string
+  /** The subject the token was issued for, if user-bound. Promoted to `user_id`. */
+  userId?: string
   /** The scopes/permissions granted, if any. */
   scopes?: string[]
 }
@@ -367,6 +370,8 @@ export interface TokenIssuedInput extends AuditInputBase {
 export interface TokenRefreshedInput extends AuditInputBase {
   /** The refreshed token's identifier (a reference, not the token value). */
   tokenId: string
+  /** The subject the token is bound to, if any. Promoted to `user_id`. */
+  userId?: string
 }
 
 /** Input for {@link ApiUsageAudit.tokenInvalidated}. @public */
@@ -375,6 +380,8 @@ export interface TokenInvalidatedInput extends AuditInputBase {
   tokenId: string
   /** Why it was invalidated, e.g. `revoked`, `expired`, `rotated`. */
   reason: string
+  /** The subject the token was bound to, if any. Promoted to `user_id`. */
+  userId?: string
 }
 
 /** Input for {@link ApiUsageAudit.sensitiveEndpointAccessed}. @public */
@@ -383,6 +390,15 @@ export interface SensitiveEndpointAccessedInput extends AuditInputBase {
   endpoint: string
   /** The HTTP method. */
   method: string
+  /**
+   * The acting principal — the API key/credential id used to make the call, a
+   * reference and never the key value. Required so no API-usage line is
+   * anonymous; pair with `userId` when the key is user-bound. Emitted as
+   * `context.key_id`.
+   */
+  keyId: string
+  /** The acting user, if the request was user-authenticated. Promoted to `user_id`. */
+  userId?: string
   /** Request parameters — caller-sanitised; keep secrets/PII out. */
   params?: AuditContext
 }


### PR DESCRIPTION
## Problem

The `apiUsage` audit helper group runs on machine/bearer-token requests (API key / auth bearer), which typically have **no authenticated `user_id`** in scope. But `tokenRefreshed`, `tokenInvalidated`, and `sensitiveEndpointAccessed` required `user_id` in `requiredScope`, and `tokenIssued` required it in the payload - so every such call emitted a spurious `Audit event missing required scope field` diagnostic.

## Change

- **`user_id` is now optional across `apiUsage`.** Dropped from `requiredScope` and promoted from the payload only when supplied (for a user-bound key). It stays the promoted top-level `user_id` facet - consistent with every other category and the cross-category correlation key - rather than moving into `context`.
- **Every event still carries a required non-user principal**, so no API-usage line is anonymous:
  - token lifecycle events: `tokenId` (already compile-time required)
  - `sensitiveEndpointAccessed`: new required **`keyId`** (the API credential id, emitted as `context.key_id`, reusing the `keyId`/`key_id` convention from `apiKeyChanged`)

## Why keep `user_id` at all?

`keyId` answers *which credential*; `user_id` answers *which person*. When a key is user-bound, carrying both lets an API call be stitched into the same user's `authn`/`dataAccess` trail. Machine tokens simply omit it.

## Notes

- `promote` already no-ops on an absent optional key (`if (value == null) continue` in `emit.ts`), so optional `userId` needs no emit-layer change.
- Regenerated the API Extractor report; added a changeset (`minor`).

## Breaking

- `sensitiveEndpointAccessed` now requires a `keyId` argument.
- `tokenIssued`'s `userId` goes from required to optional (safe widening).

## Test plan

- [x] `npm run test` (83 passing) - added coverage for a bearer request with no `user_id` (no diagnostic) and `keyId` in context
- [x] `npm run lint`
- [x] typecheck + regenerated API report

🤖 Generated with [Claude Code](https://claude.com/claude-code)