### PR TITLE
fix(release): pin npm to 11.x to fix missing sigstore module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        # npm@12 ships a broken bundle that can't resolve `sigstore`, breaking
+        # `npm publish --provenance`. Stay on 11.x (>=11.5.1 supports OIDC).
+        run: npm install -g npm@^11
 
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile
@@ -106,7 +108,9 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        # npm@12 ships a broken bundle that can't resolve `sigstore`, breaking
+        # `npm publish --provenance`. Stay on 11.x (>=11.5.1 supports OIDC).
+        run: npm install -g npm@^11
 
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile


### PR DESCRIPTION
## Problem

The release workflow fails during publish with:

```
npm error Cannot find module 'sigstore'
```

npm@12.0.0 ships a broken bundle whose `libnpmpublish/provenance.js` cannot resolve `sigstore`, so `npm publish --provenance` dies. Our release steps run `npm install -g npm@latest`, which now pulls the broken v12.

## Fix

Pin the global npm upgrade to `npm@^11`. The 11.x line still bundles `sigstore` and supports OIDC trusted publishing (>= 11.5.1). Applied to both jobs in `release.yml`.

Ref: https://github.com/wingfoil-io/wingfoil/pull/421

🤖 Generated with [Claude Code](https://claude.com/claude-code)