### PR TITLE
feat(logging): make traceId optional, rely on dd-trace log injection

### DIFF
--- a/.changeset/wild-trains-tease.md
+++ b/.changeset/wild-trains-tease.md
@@ -1,0 +1,7 @@
+---
+"@opengovsg/starter-kitty-logging": minor
+---
+
+`traceId` is now optional on request loggers (`LoggerOptions`).
+Trace correlation should come from dd-trace log injection (`DD_LOGS_INJECTION`, on by default), which stamps `dd.trace_id` from the active span onto every line - resolved per line, so it also works across jobs, queues, and cron, where no request headers exist.
+Passing `traceId` still binds a root `trace_id` for non-APM sinks; existing callers are unaffected.

--- a/apps/docs/examples/logging.md
+++ b/apps/docs/examples/logging.md
@@ -32,6 +32,15 @@ Call `createLogging` once and re-export the result. `env`, `service`, and
 `version` are required; `level` (default `info`) and `pretty` (default `false`)
 are optional. The factory is immutable and never throws.
 
+Trace correlation needs no wiring: with dd-trace running, log injection
+(`DD_LOGS_INJECTION`, on by default) stamps `dd.trace_id` from the active span
+onto every line - including jobs, queues, and cron - and Datadog correlates on
+it natively.
+Just initialise dd-trace before pino loads (ESM apps:
+`node --import dd-trace/register.js`).
+The optional per-logger `traceId` exists only for non-APM sinks; use
+`correlationId` for a gateway-minted ID chained across systems.
+
 ## Logging
 
 ```javascript
@@ -40,7 +49,6 @@ import { createBaseLogger } from '~/logger'
 const logger = createBaseLogger({
   path: '/api/widgets',
   source: req.headers.get('x-source'),
-  traceId: req.headers.get('x-trace-id'),
   clientIp: req.headers.get('cf-connecting-ip'),
   userAgent: req.headers.get('user-agent'),
 })
@@ -48,8 +56,10 @@ const logger = createBaseLogger({
 logger.info({ message: 'Widget fetched', action: 'getWidget', context: { widget_id: widgetId } })
 ```
 
-Request-scoped loggers require `traceId`, `clientIp`, and `userAgent` keys (they
-accept `string | null | undefined`, so a missing header passes `null`).
+Request-scoped loggers require `clientIp` and `userAgent` keys (they accept
+`string | null | undefined`, so a missing header passes `null`).
+`traceId` is optional everywhere - trace correlation comes from dd-trace log
+injection, not headers.
 
 ```javascript
 const startupLogger = createBaseLogger.system({ path: 'redis:startup' })

--- a/etc/starter-kitty-logging.api.md
+++ b/etc/starter-kitty-logging.api.md
@@ -164,7 +164,6 @@ export interface Logger {
 // @public
 export interface LoggerOptions extends SystemLoggerOptions {
     clientIp: string | null | undefined;
-    traceId: string | null | undefined;
     userAgent: string | null | undefined;
 }
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -32,6 +32,20 @@ export const createBaseLogger = createLogging({
 })
 ```
 
+### Trace correlation
+
+Trace correlation needs no wiring in this package.
+With dd-trace running, log injection (`DD_LOGS_INJECTION`, on by default)
+stamps `dd.trace_id` from the active span onto every pino line - resolved per
+line, so it also works in jobs, queue consumers, and cron - and Datadog
+correlates logs with traces on it natively.
+Just initialise dd-trace before pino loads (ESM apps:
+`node --import dd-trace/register.js`).
+
+The optional per-logger `traceId` still binds a root `trace_id` for non-APM
+sinks that need one under this schema's own key.
+For a gateway-minted ID chained across systems, use `correlationId` instead.
+
 ## Usage
 
 Import your app's re-exported factory anywhere and create a logger. There are
@@ -40,16 +54,16 @@ two shapes, by context:
 ```ts
 import { createBaseLogger } from '~/logger'
 
-// Request-scoped — inside an HTTP handler. `traceId`, `clientIp`, and
-// `userAgent` are REQUIRED KEYS (a compile error if omitted) but accept
+// Request-scoped — inside an HTTP handler. `clientIp` and `userAgent` are
+// REQUIRED KEYS (a compile error if omitted) but accept
 // `string | null | undefined`: you must acknowledge them, and pass
 // `null`/`undefined` when the header is genuinely missing. `headers.get(...)`
 // returns `string | null`, which is accepted directly — a `null` value is
-// simply omitted from the line.
+// simply omitted from the line. `trace_id` comes from dd-trace log injection
+// (see "Trace correlation" above), so no `traceId` is passed here.
 const logger = createBaseLogger({
   path: '/api/widgets',
   source: req.headers.get('x-source'),
-  traceId: req.headers.get('x-trace-id'),
   clientIp: req.headers.get('cf-connecting-ip'),
   userAgent: req.headers.get('user-agent'),
 })
@@ -71,6 +85,8 @@ startupLogger.info({ message: 'Redis connected', action: 'boot' })
 > header) without forcing fake values where they don't. Header-sourced fields
 > (`source`, `traceId`, `clientIp`, `userAgent`, `clientVersion`) accept `null`
 > and are omitted from the line rather than emitted as `null`.
+> `traceId` is optional everywhere: trace correlation comes from dd-trace log
+> injection, not headers.
 
 ## Wire schema
 

--- a/packages/logging/src/__tests__/logger.test.ts
+++ b/packages/logging/src/__tests__/logger.test.ts
@@ -145,9 +145,14 @@ describe('wire format', () => {
   })
 
   it('does not require traceId on a system logger (omitted when absent)', () => {
-    // `traceId` is request-only; a system logger needs no distributed trace, so
-    // the key is optional and absent from the line when not supplied.
+    // Trace correlation comes from dd-trace log injection, so `traceId` is
+    // optional everywhere; the key is absent from the line when not supplied.
     createBaseLogger.system({ path: 'redis:startup' }).info({ message: 'up', action: 'boot' })
+    expect(entryAt(0)).not.toHaveProperty('trace_id')
+  })
+
+  it('does not require traceId on a request logger (omitted when absent)', () => {
+    createBaseLogger({ path: '/api', clientIp: '1.2.3.4', userAgent: 'jest' }).info({ message: 'm', action: 'a' })
     expect(entryAt(0)).not.toHaveProperty('trace_id')
   })
 

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -64,12 +64,15 @@ export interface SystemLoggerOptions {
   /** Where the log originated, e.g. `trpc` / `rest`. Bound as `source`. Accepts `null` (e.g. from `headers.get`). */
   source?: string | null
   /**
-   * Distributed-trace correlation ID, bound as `trace_id` — the key that chains
-   * a request's lines together. **Optional** here: request-less contexts
-   * (startup, jobs, cron, CLI) have no distributed trace, so it is simply
-   * omitted rather than forced. On request loggers it is a required key — see
-   * {@link LoggerOptions.traceId}. Accepts `null` (e.g. from `headers.get`); a
-   * `null` value is omitted from the line.
+   * Distributed-trace correlation ID, bound as `trace_id`. **Usually leave this
+   * unset**: with dd-trace running, log injection (`DD_LOGS_INJECTION`, on by
+   * default) already stamps `dd.trace_id` on every line from the active span -
+   * per line, so it also works in jobs, queues, and cron, and Datadog
+   * correlates on it natively. Set this only for a non-APM sink that needs a
+   * trace id under this schema's own `trace_id` key; for a gateway-minted ID
+   * chained across systems, use {@link SystemLoggerOptions.correlationId}
+   * instead. Accepts `null` (e.g. from `headers.get`); a `null` value is
+   * omitted from the line.
    */
   traceId?: string | null
   /** The acting user's ID. Bound as `user_id` — the canonical user-correlation facet. */
@@ -87,23 +90,18 @@ export interface SystemLoggerOptions {
 /**
  * Per-request metadata for a request-scoped {@link Logger}. Extends
  * {@link SystemLoggerOptions} with the request identity every request line should
- * carry. `traceId`, `clientIp`, and `userAgent` are **required keys** that accept
+ * carry. `clientIp` and `userAgent` are **required keys** that accept
  * `string | null | undefined`: the caller must *acknowledge* them — forgetting
  * the key is a compile error — and pass `null`/`undefined` explicitly when the
  * value is genuinely absent (e.g. a missing `headers.get(...)`), rather than
- * leaving it off by accident. For request-less contexts use
- * {@link SystemLoggerOptions} via `createLogging(...).system(...)`, where
- * `traceId` is optional and the client identity does not exist.
+ * leaving it off by accident. `traceId` is optional: trace correlation comes
+ * from dd-trace log injection (see {@link SystemLoggerOptions.traceId}). For
+ * request-less contexts use {@link SystemLoggerOptions} via
+ * `createLogging(...).system(...)`, where the client identity does not exist.
  *
  * @public
  */
 export interface LoggerOptions extends SystemLoggerOptions {
-  /**
-   * Distributed-trace correlation ID, bound as `trace_id` — the key that chains
-   * a request's lines together. Required key on requests — pass `null`/`undefined`
-   * if there is genuinely no trace; it is never silently forgotten.
-   */
-  traceId: string | null | undefined
   /**
    * The originating client IP (vendor-neutral; not edge-specific). Bound as
    * `client_ip`. Required key — pass `null`/`undefined` if the header is absent.


### PR DESCRIPTION
## Summary

Closes [DEVX-2](https://linear.app/ogp/issue/DEVX-2/starter-kitty-logging-trace-id-should-take-from-dd-agent-instead-of): trace id should come from the dd agent instead of headers, so correlation works across jobs, queues, etc.

It turns out this needs no code in the package at all. dd-trace log injection (`DD_LOGS_INJECTION`, on by default in current dd-trace-js) stamps `dd.trace_id` from the active span onto every pino line, resolved per line - so it works in jobs, queue consumers, and cron, where no request headers exist - and Datadog correlates logs with traces on it natively. The only requirement is initialising dd-trace before pino loads (ESM apps: `node --import dd-trace/register.js`).

## Changes

- `traceId` demoted from a required key on `LoggerOptions` to the optional key inherited from `SystemLoggerOptions`. Non-breaking: existing `traceId: null` callers compile and behave identically; passing a value still binds a root `trace_id` for non-APM sinks.
- JSDoc, README, and the docs example now document dd-trace log injection as the trace-correlation path, and point to `correlationId` for gateway-minted IDs chained across systems.
- Test added for omitting `traceId` on a request logger; API report regenerated (surface diff is the single key demotion); minor changeset.

## Testing

- `vitest run` - 84 tests pass
- `api-extractor` (ci:report), eslint, prettier all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
