### PR TITLE
feat(testcontainers): core container wrapper and presets

### DIFF
--- a/etc/starter-kitty-testcontainers.api.md
+++ b/etc/starter-kitty-testcontainers.api.md
@@ -4,4 +4,107 @@
 
 ```ts
 
+import type { StartedNetwork } from 'testcontainers';
+import type { StartedTestContainer } from 'testcontainers';
+import { z } from 'zod';
+
+// @public
+export interface ContainerConfiguration {
+    // (undocumented)
+    command?: string[];
+    // (undocumented)
+    environment?: Record<string, string>;
+    // (undocumented)
+    extraHosts?: {
+        host: string;
+        ipAddress: string;
+    }[];
+    // (undocumented)
+    image: string;
+    name: string;
+    ports?: (number | {
+        container: number;
+        host: number;
+    })[];
+    reuse?: boolean;
+    // (undocumented)
+    wait?: WaitStrategy;
+}
+
+// @public
+export const containerConfigurationSchema: z.ZodType<ContainerConfiguration>;
+
+// @public
+export interface ContainerInformation {
+    // (undocumented)
+    configuration: ContainerConfiguration;
+    // (undocumented)
+    host: string;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    ports: Map<number, number>;
+}
+
+// @public
+export const getContainer: (name: string) => ContainerInformation;
+
+// @public
+export const getMappedPort: (container: ContainerInformation, containerPort: number) => number;
+
+// @public
+export const getPostgresConnectionString: (container: ContainerInformation, options?: {
+    database?: string;
+}) => string;
+
+// @public
+export const getRedisUrl: (container: ContainerInformation) => string;
+
+// @public
+export const parseContainers: (serialized: string) => ContainerInformation[];
+
+// @public
+export const postgres: (overrides?: Partial<ContainerConfiguration>) => ContainerConfiguration;
+
+// @public
+export const redis: (overrides?: Partial<ContainerConfiguration> & {
+    databases?: number;
+}) => ContainerConfiguration;
+
+// @public
+export const serializeContainers: (containers: StartedContainerInformation[]) => string;
+
+// @public
+export const setup: (configurations: ContainerConfiguration[], options?: {
+    network?: StartedNetwork;
+}) => Promise<StartedContainerInformation[]>;
+
+// @public
+export interface StartedContainerInformation extends ContainerInformation {
+    // (undocumented)
+    container: StartedTestContainer;
+}
+
+// @public
+export const teardown: (containers: {
+    container: StartedTestContainer;
+}[]) => Promise<void>;
+
+// @public
+export const TESTCONTAINERS_ENV_KEY = "testcontainers";
+
+// @public
+export type WaitStrategy = {
+    type: 'PORT';
+    timeout?: number;
+} | {
+    type: 'LOG';
+    message: string;
+    times?: number;
+    timeout?: number;
+} | {
+    type: 'HEALTHCHECK';
+    timeout?: number;
+};
+
 ```

--- a/packages/testcontainers/src/__tests__/config.test.ts
+++ b/packages/testcontainers/src/__tests__/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { containerConfigurationSchema } from '../config.js'
+
+describe('containerConfigurationSchema', () => {
+  it('parses a full configuration', () => {
+    const config = {
+      name: 'db',
+      image: 'postgres:latest',
+      ports: [5432, { container: 6379, host: 63799 }],
+      environment: { FOO: 'bar' },
+      command: ['redis-server'],
+      extraHosts: [{ host: 'host.docker.internal', ipAddress: 'host-gateway' }],
+      reuse: true,
+      wait: { type: 'LOG', message: 'ready', times: 2 },
+    }
+    expect(containerConfigurationSchema.parse(config)).toEqual(config)
+  })
+
+  it('drops unknown keys such as the removed buildArgs', () => {
+    const parsed = containerConfigurationSchema.parse({
+      name: 'db',
+      image: 'postgres',
+      buildArgs: { NODE_ENV: 'test' },
+    })
+    expect(parsed).not.toHaveProperty('buildArgs')
+  })
+
+  it('rejects a config missing image', () => {
+    expect(() => containerConfigurationSchema.parse({ name: 'db' })).toThrow()
+  })
+
+  it('rejects an unknown wait strategy', () => {
+    expect(() =>
+      containerConfigurationSchema.parse({
+        name: 'db',
+        image: 'postgres',
+        wait: { type: 'SLEEP' },
+      }),
+    ).toThrow()
+  })
+})

--- a/packages/testcontainers/src/__tests__/handoff.test.ts
+++ b/packages/testcontainers/src/__tests__/handoff.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ContainerConfiguration } from '../config.js'
+import {
+  getContainer,
+  getMappedPort,
+  parseContainers,
+  serializeContainers,
+  TESTCONTAINERS_ENV_KEY,
+} from '../handoff.js'
+import type { StartedContainerInformation } from '../setup.js'
+
+const configuration: ContainerConfiguration = {
+  name: 'redis',
+  image: 'redis',
+  ports: [6379],
+  wait: { type: 'PORT' },
+}
+
+const started = {
+  name: 'redis',
+  host: '127.0.0.1',
+  ports: new Map([[6379, 32768]]),
+  configuration,
+  // Not serialized, so a stub is enough.
+  container: {} as StartedContainerInformation['container'],
+} satisfies StartedContainerInformation
+
+describe('serialize/parse handoff', () => {
+  it('round-trips container info, rebuilding the ports Map', () => {
+    const [parsed] = parseContainers(serializeContainers([started]))
+    expect(parsed).toBeDefined()
+    expect(parsed?.ports).toBeInstanceOf(Map)
+    expect(parsed?.ports.get(6379)).toBe(32768)
+    expect(parsed).toEqual({
+      name: 'redis',
+      host: '127.0.0.1',
+      ports: new Map([[6379, 32768]]),
+      configuration,
+    })
+  })
+
+  it('never serializes the live container handle', () => {
+    expect(serializeContainers([started])).not.toContain('container')
+  })
+})
+
+describe('getContainer', () => {
+  afterEach(() => {
+    delete process.env[TESTCONTAINERS_ENV_KEY]
+  })
+
+  it('finds a container by name from the env', () => {
+    process.env[TESTCONTAINERS_ENV_KEY] = serializeContainers([started])
+    expect(getContainer('redis').host).toBe('127.0.0.1')
+  })
+
+  it('throws when the env var is absent', () => {
+    expect(() => getContainer('redis')).toThrow(/is not set/)
+  })
+
+  it('throws when no container matches the name', () => {
+    process.env[TESTCONTAINERS_ENV_KEY] = serializeContainers([started])
+    expect(() => getContainer('postgres')).toThrow(/No container named/)
+  })
+})
+
+describe('getMappedPort', () => {
+  it('returns the mapped host port', () => {
+    expect(getMappedPort(started, 6379)).toBe(32768)
+  })
+
+  it('throws for an unmapped port', () => {
+    expect(() => getMappedPort(started, 5432)).toThrow(/no mapped port/)
+  })
+})

--- a/packages/testcontainers/src/__tests__/presets.test.ts
+++ b/packages/testcontainers/src/__tests__/presets.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPostgresConnectionString, getRedisUrl, postgres, redis } from '../presets.js'
+import type { ContainerInformation } from '../setup.js'
+
+describe('postgres preset', () => {
+  it('has sensible defaults', () => {
+    expect(postgres()).toEqual({
+      name: 'postgres',
+      image: 'postgres:latest',
+      ports: [5432],
+      environment: {
+        POSTGRES_DB: 'test',
+        POSTGRES_USER: 'root',
+        POSTGRES_PASSWORD: 'root',
+      },
+      wait: { type: 'PORT' },
+    })
+  })
+
+  it('shallow-merges overrides but merges environment per-key', () => {
+    const config = postgres({
+      ports: [{ container: 5432, host: 64322 }],
+      reuse: true,
+      environment: { POSTGRES_DB: 'custom' },
+    })
+    expect(config.ports).toEqual([{ container: 5432, host: 64322 }])
+    expect(config.reuse).toBe(true)
+    expect(config.environment).toEqual({
+      POSTGRES_DB: 'custom',
+      POSTGRES_USER: 'root',
+      POSTGRES_PASSWORD: 'root',
+    })
+  })
+})
+
+describe('redis preset', () => {
+  it('has sensible defaults and no command', () => {
+    expect(redis()).toEqual({
+      name: 'redis',
+      image: 'redis',
+      ports: [6379],
+      wait: { type: 'PORT' },
+    })
+  })
+
+  it('adds a --databases command when databases is set', () => {
+    expect(redis({ databases: 256 }).command).toEqual(['redis-server', '--databases', '256'])
+  })
+
+  it('applies overrides without leaking the databases key', () => {
+    const config = redis({ databases: 16, reuse: true })
+    expect(config.reuse).toBe(true)
+    expect(config).not.toHaveProperty('databases')
+  })
+})
+
+const pgInfo: ContainerInformation = {
+  name: 'postgres',
+  host: 'localhost',
+  ports: new Map([[5432, 54321]]),
+  configuration: postgres(),
+}
+
+describe('connection string builders', () => {
+  it('builds a Postgres connection string from env creds', () => {
+    expect(getPostgresConnectionString(pgInfo)).toBe('postgresql://root:root@localhost:54321/test?sslmode=disable')
+  })
+
+  it('overrides the database name', () => {
+    expect(getPostgresConnectionString(pgInfo, { database: 'run-123' })).toBe(
+      'postgresql://root:root@localhost:54321/run-123?sslmode=disable',
+    )
+  })
+
+  it('builds a redis url', () => {
+    expect(
+      getRedisUrl({
+        name: 'redis',
+        host: 'localhost',
+        ports: new Map([[6379, 63790]]),
+        configuration: redis(),
+      }),
+    ).toBe('redis://localhost:63790')
+  })
+})

--- a/packages/testcontainers/src/__tests__/setup.docker.test.ts
+++ b/packages/testcontainers/src/__tests__/setup.docker.test.ts
@@ -1,0 +1,53 @@
+import { connect } from 'node:net'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { getContainer, parseContainers, serializeContainers, TESTCONTAINERS_ENV_KEY } from '../handoff.js'
+import { getPostgresConnectionString, getRedisUrl, postgres, redis } from '../presets.js'
+import { setup, type StartedContainerInformation, teardown } from '../setup.js'
+
+/** Resolve once a TCP connection to host:port succeeds. */
+const canConnect = (host: string, port: number) =>
+  new Promise<boolean>(resolve => {
+    const socket = connect({ host, port }, () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.on('error', () => resolve(false))
+  })
+
+// Real Docker required; pulls postgres + redis on first run.
+describe('setup/teardown against real Docker', () => {
+  let containers: StartedContainerInformation[]
+
+  beforeAll(async () => {
+    containers = await setup([postgres(), redis()])
+    process.env[TESTCONTAINERS_ENV_KEY] = serializeContainers(containers)
+  }, 180_000)
+
+  afterAll(async () => {
+    delete process.env[TESTCONTAINERS_ENV_KEY]
+    await teardown(containers)
+  })
+
+  it('exposes reachable, port-mapped containers', async () => {
+    for (const c of containers) {
+      const containerPort = c.name === 'postgres' ? 5432 : 6379
+      const hostPort = c.ports.get(containerPort)
+      expect(hostPort).toBeTypeOf('number')
+      expect(await canConnect(c.host, hostPort!)).toBe(true)
+    }
+  })
+
+  it('round-trips real container info through the env handoff', () => {
+    const parsed = parseContainers(process.env[TESTCONTAINERS_ENV_KEY]!)
+    expect(parsed.map(c => c.name).sort()).toEqual(['postgres', 'redis'])
+    expect(parsed[0]?.ports).toBeInstanceOf(Map)
+  })
+
+  it('builds connection strings pointing at the live containers', () => {
+    const pgUrl = getPostgresConnectionString(getContainer('postgres'))
+    expect(pgUrl).toMatch(/^postgresql:\/\/root:root@.+\/test\?sslmode=disable$/)
+    expect(getRedisUrl(getContainer('redis'))).toMatch(/^redis:\/\/.+:\d+$/)
+  })
+})

--- a/packages/testcontainers/src/config.ts
+++ b/packages/testcontainers/src/config.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod'
+
+/**
+ * Wait strategy applied before a container is considered ready. Mirrors the
+ * three `testcontainers` strategies confetti relied on; `timeout` is the
+ * startup timeout in milliseconds (default 60000).
+ *
+ * @public
+ */
+export type WaitStrategy =
+  | { type: 'PORT'; timeout?: number }
+  | { type: 'LOG'; message: string; times?: number; timeout?: number }
+  | { type: 'HEALTHCHECK'; timeout?: number }
+
+/**
+ * Declarative description of a single container. Ported from confetti's zod
+ * schema minus `buildArgs` (it was declared but never applied).
+ *
+ * @public
+ */
+export interface ContainerConfiguration {
+  /** Unique name; also used as the network alias when a network is passed. */
+  name: string
+  image: string
+  /**
+   * Ports to expose. A bare number requests a random host port; an object
+   * pins a fixed host port (the e2e reuse pattern).
+   */
+  ports?: (number | { container: number; host: number })[]
+  environment?: Record<string, string>
+  command?: string[]
+  extraHosts?: { host: string; ipAddress: string }[]
+  /** `withReuse()` — e2e reruns share containers; Ryuk reaps them on exit. */
+  reuse?: boolean
+  wait?: WaitStrategy
+}
+
+const waitStrategySchema: z.ZodType<WaitStrategy> = z.union([
+  z.object({ type: z.literal('PORT'), timeout: z.number().optional() }),
+  z.object({
+    type: z.literal('LOG'),
+    message: z.string(),
+    times: z.number().optional(),
+    timeout: z.number().optional(),
+  }),
+  z.object({ type: z.literal('HEALTHCHECK'), timeout: z.number().optional() }),
+])
+
+/**
+ * Zod schema validating a {@link ContainerConfiguration}. Unknown keys (such as
+ * the removed `buildArgs`) are stripped.
+ *
+ * @public
+ */
+export const containerConfigurationSchema: z.ZodType<ContainerConfiguration> = z.object({
+  name: z.string(),
+  image: z.string(),
+  ports: z.array(z.union([z.number(), z.object({ container: z.number(), host: z.number() })])).optional(),
+  environment: z.record(z.string(), z.string()).optional(),
+  command: z.array(z.string()).optional(),
+  extraHosts: z.array(z.object({ host: z.string(), ipAddress: z.string() })).optional(),
+  reuse: z.boolean().optional(),
+  wait: waitStrategySchema.optional(),
+})

--- a/packages/testcontainers/src/handoff.ts
+++ b/packages/testcontainers/src/handoff.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+
+import { containerConfigurationSchema } from './config.js'
+import type { ContainerInformation, StartedContainerInformation } from './setup.js'
+
+/**
+ * The `process.env` key the global setup writes serialized container info to,
+ * and test files read it back from.
+ *
+ * @public
+ */
+export const TESTCONTAINERS_ENV_KEY = 'testcontainers'
+
+/**
+ * Wire schema for the env handoff. Plain JSON (no superjson): the `ports` Map
+ * travels as an array of `[containerPort, hostPort]` entries and is rebuilt
+ * into a Map on parse.
+ */
+const containersWireSchema: z.ZodType<ContainerInformation[]> = z.array(
+  z
+    .object({
+      name: z.string(),
+      host: z.string(),
+      ports: z.array(z.tuple([z.number(), z.number()])),
+      configuration: containerConfigurationSchema,
+    })
+    .transform(c => ({ ...c, ports: new Map<number, number>(c.ports) })),
+)
+
+/**
+ * Serialize started containers to a JSON string for the env handoff.
+ *
+ * @public
+ */
+export const serializeContainers = (containers: StartedContainerInformation[]): string =>
+  JSON.stringify(
+    containers.map(({ name, host, ports, configuration }) => ({
+      name,
+      host,
+      ports: [...ports.entries()],
+      configuration,
+    })),
+  )
+
+/**
+ * Parse a serialized handoff string back into container info.
+ *
+ * @public
+ */
+export const parseContainers = (serialized: string): ContainerInformation[] =>
+  containersWireSchema.parse(JSON.parse(serialized))
+
+/**
+ * Read `process.env[TESTCONTAINERS_ENV_KEY]` and return the container with the
+ * given name. Throws if the env var is absent or no container matches.
+ *
+ * @public
+ */
+export const getContainer = (name: string): ContainerInformation => {
+  const serialized = process.env[TESTCONTAINERS_ENV_KEY]
+  if (!serialized) {
+    throw new Error(`process.env.${TESTCONTAINERS_ENV_KEY} is not set; did the global setup run?`)
+  }
+  const container = parseContainers(serialized).find(c => c.name === name)
+  if (!container) {
+    throw new Error(`No container named "${name}" in the env handoff`)
+  }
+  return container
+}
+
+/**
+ * Return the mapped host port for a container port. Throws if unmapped.
+ *
+ * @public
+ */
+export const getMappedPort = (container: ContainerInformation, containerPort: number): number => {
+  const mapped = container.ports.get(containerPort)
+  if (mapped === undefined) {
+    throw new Error(`Container "${container.name}" has no mapped port for ${containerPort}`)
+  }
+  return mapped
+}

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -7,5 +7,7 @@
  * @packageDocumentation
  */
 
-// Implementation lands in DEVX-58; see the v1 API sketch on the map (DEVX-55).
-export {}
+export * from './config.js'
+export * from './handoff.js'
+export * from './presets.js'
+export * from './setup.js'

--- a/packages/testcontainers/src/presets.ts
+++ b/packages/testcontainers/src/presets.ts
@@ -1,0 +1,93 @@
+import type { ContainerConfiguration } from './config.js'
+import { getMappedPort } from './handoff.js'
+import type { ContainerInformation } from './setup.js'
+
+/**
+ * Merge overrides onto a base config: shallow for all keys, but `environment`
+ * merges per-key so overriding one var keeps the preset's others.
+ */
+const withOverrides = (
+  base: ContainerConfiguration,
+  overrides: Partial<ContainerConfiguration>,
+): ContainerConfiguration => {
+  const environment =
+    base.environment || overrides.environment ? { ...base.environment, ...overrides.environment } : undefined
+  const merged = { ...base, ...overrides }
+  if (environment) {
+    merged.environment = environment
+  }
+  return merged
+}
+
+/**
+ * Postgres preset: `postgres:latest` on port 5432 with
+ * `POSTGRES_DB=test`/`POSTGRES_USER=root`/`POSTGRES_PASSWORD=root`, waiting on
+ * the port. Overrides shallow-merge; `environment` merges per-key.
+ *
+ * @public
+ */
+export const postgres = (overrides: Partial<ContainerConfiguration> = {}): ContainerConfiguration =>
+  withOverrides(
+    {
+      name: 'postgres',
+      image: 'postgres:latest',
+      ports: [5432],
+      environment: {
+        POSTGRES_DB: 'test',
+        POSTGRES_USER: 'root',
+        POSTGRES_PASSWORD: 'root',
+      },
+      wait: { type: 'PORT' },
+    },
+    overrides,
+  )
+
+/**
+ * Redis preset: `redis` on port 6379, waiting on the port. `databases` starts
+ * the server with `--databases n` for per-worker logical-DB isolation
+ * (confetti uses 256).
+ *
+ * @public
+ */
+export const redis = (
+  overrides: Partial<ContainerConfiguration> & { databases?: number } = {},
+): ContainerConfiguration => {
+  const { databases, ...rest } = overrides
+  const base: ContainerConfiguration = {
+    name: 'redis',
+    image: 'redis',
+    ports: [6379],
+    wait: { type: 'PORT' },
+  }
+  if (databases !== undefined) {
+    base.command = ['redis-server', '--databases', String(databases)]
+  }
+  return withOverrides(base, rest)
+}
+
+/**
+ * Build a Postgres connection string from container info. Credentials are read
+ * back from `configuration.environment`; `database` overrides the DB name (the
+ * confetti per-run `randomUUID()` pattern).
+ *
+ * @public
+ */
+export const getPostgresConnectionString = (
+  container: ContainerInformation,
+  options: { database?: string } = {},
+): string => {
+  const env = container.configuration.environment ?? {}
+  const user = env.POSTGRES_USER ?? 'root'
+  const password = env.POSTGRES_PASSWORD ?? 'root'
+  const database = options.database ?? env.POSTGRES_DB ?? 'test'
+  const port = getMappedPort(container, 5432)
+  return `postgresql://${user}:${password}@${container.host}:${port}/${database}?sslmode=disable`
+}
+
+/**
+ * Build a `redis://host:port` URL from container info.
+ *
+ * @public
+ */
+export const getRedisUrl = (container: ContainerInformation): string =>
+  `redis://${container.host}:${getMappedPort(container, 6379)}`

--- a/packages/testcontainers/src/setup.ts
+++ b/packages/testcontainers/src/setup.ts
@@ -1,0 +1,116 @@
+import type { StartedNetwork, StartedTestContainer } from 'testcontainers'
+import { GenericContainer, Wait } from 'testcontainers'
+
+import type { ContainerConfiguration } from './config.js'
+
+/**
+ * The serializable slice of a started container — what test files see after
+ * the env handoff. `ports` maps each exposed container port to its mapped host
+ * port.
+ *
+ * @public
+ */
+export interface ContainerInformation {
+  name: string
+  host: string
+  ports: Map<number, number>
+  configuration: ContainerConfiguration
+}
+
+/**
+ * A {@link ContainerInformation} plus the live, non-serializable handle.
+ *
+ * @public
+ */
+export interface StartedContainerInformation extends ContainerInformation {
+  container: StartedTestContainer
+}
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 60 * 1000
+
+/**
+ * Start the given containers concurrently and return their connection info.
+ * Faithful port of confetti's `common.ts` setup, with the optional network
+ * moved into an options object.
+ *
+ * @public
+ */
+export const setup = async (
+  configurations: ContainerConfiguration[],
+  options: { network?: StartedNetwork } = {},
+): Promise<StartedContainerInformation[]> => {
+  const { network } = options
+
+  const templates = configurations.map(configuration => {
+    const { name, image, extraHosts, ports = [], environment, command, wait, reuse } = configuration
+
+    let container = new GenericContainer(image)
+
+    if (ports.length) {
+      container = container.withExposedPorts(...ports)
+    }
+    if (extraHosts) {
+      container = container.withExtraHosts(extraHosts)
+    }
+    if (environment) {
+      container = container.withEnvironment(environment)
+    }
+    if (command) {
+      container = container.withCommand(command)
+    }
+    if (network) {
+      container = container.withNetwork(network).withNetworkAliases(name)
+    }
+    if (reuse) {
+      container = container.withReuse()
+    }
+    if (wait) {
+      const { timeout = DEFAULT_STARTUP_TIMEOUT_MS } = wait
+      container = container.withStartupTimeout(timeout)
+      switch (wait.type) {
+        case 'PORT':
+          container = container.withWaitStrategy(Wait.forListeningPorts())
+          break
+        case 'LOG':
+          container = container.withWaitStrategy(Wait.forLogMessage(wait.message, wait.times ?? 1))
+          break
+        case 'HEALTHCHECK':
+          container = container.withWaitStrategy(Wait.forHealthCheck())
+          break
+      }
+    }
+
+    return {
+      name,
+      container,
+      configuration,
+      containerPorts: ports.map(port => (typeof port === 'number' ? port : port.container)),
+    }
+  })
+
+  return Promise.all(
+    templates.map(async ({ name, container, configuration, containerPorts }) => {
+      const started = await container.start()
+      const ports = new Map<number, number>()
+      for (const port of containerPorts) {
+        ports.set(port, started.getMappedPort(port))
+      }
+      return {
+        name,
+        host: started.getHost(),
+        ports,
+        configuration,
+        container: started,
+      }
+    }),
+  )
+}
+
+/**
+ * Stop and remove the given containers concurrently.
+ *
+ * @public
+ */
+export const teardown = async (containers: { container: StartedTestContainer }[]): Promise<void> => {
+  await Promise.all(containers.map(({ container }) => container.stop({ remove: true })))
+}

--- a/packages/testcontainers/vitest.config.ts
+++ b/packages/testcontainers/vitest.config.ts
@@ -1,6 +1,1 @@
-export default {
-  test: {
-    // ponytail: scaffold has no tests yet; remove once DEVX-58 adds them
-    passWithNoTests: true,
-  },
-}
+export default {}


### PR DESCRIPTION
## What

Implements the core of `@opengovsg/starter-kitty-testcontainers` (DEVX-58), porting confetti's `apps/web/tests/common.ts` into the package per the [v1 API sketch](https://linear.app/ogp/document/opengovsgstarter-kitty-testcontainers-v1-api-sketch-701c897d073f).

- **Config schema** `containerConfigurationSchema` (zod) - confetti's shape minus the never-applied `buildArgs`, with a named `WaitStrategy` union (PORT/LOG/HEALTHCHECK).
- **`setup`/`teardown`** over `GenericContainer` - faithful port, with the optional network moved into an options object.
- **Env handoff** (`handoff.ts`): plain JSON, no superjson. The `ports` Map travels as `[containerPort, hostPort]` entries and is rebuilt via a zod `.transform`. `serializeContainers`/`parseContainers` plus `getContainer`/`getMappedPort` accessors.
- **Presets**: `postgres()`/`redis({ databases })` with shallow override merge (environment merges per-key), plus `getPostgresConnectionString`/`getRedisUrl`.

The `/vitest` glue (`createGlobalSetup`, `getWorkerDatabaseIndex`) is out of scope here - it lands in DEVX-59.

## Tests

- Pure-logic unit tests for schema, handoff round-trip, presets, and connection strings.
- A Docker-backed integration test that boots both presets, TCP-checks the mapped ports are reachable, round-trips real container info through the handoff, and tears down.

All 22 tests pass locally against real Docker; `build`, `lint`, and `ci:report` are green.

Refs DEVX-58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)