### PR TITLE
feat(testcontainers): vitest globalSetup and worker-db helpers

### DIFF
--- a/packages/testcontainers/src/__tests__/vitest.docker.test.ts
+++ b/packages/testcontainers/src/__tests__/vitest.docker.test.ts
@@ -1,0 +1,32 @@
+import { connect } from 'node:net'
+
+import { describe, expect, it } from 'vitest'
+
+import { getContainer, getMappedPort, TESTCONTAINERS_ENV_KEY } from '../handoff.js'
+import { redis } from '../presets.js'
+import { createGlobalSetup } from '../vitest/index.js'
+
+/** Resolve once a TCP connection to host:port succeeds. */
+const canConnect = (host: string, port: number) =>
+  new Promise<boolean>(resolve => {
+    const socket = connect({ host, port }, () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.on('error', () => resolve(false))
+  })
+
+// Real Docker required; boots a single redis container via the globalSetup factory.
+describe('createGlobalSetup against real Docker', () => {
+  it('boots a container, publishes the handoff, and tears down', async () => {
+    const teardown = await createGlobalSetup([redis()])()
+    try {
+      expect(process.env[TESTCONTAINERS_ENV_KEY]).toBeTypeOf('string')
+      const info = getContainer('redis')
+      expect(await canConnect(info.host, getMappedPort(info, 6379))).toBe(true)
+    } finally {
+      await teardown()
+    }
+    expect(process.env[TESTCONTAINERS_ENV_KEY]).toBeUndefined()
+  }, 180_000)
+})

--- a/packages/testcontainers/src/__tests__/vitest.test.ts
+++ b/packages/testcontainers/src/__tests__/vitest.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getWorkerDatabaseIndex } from '../vitest/index.js'
+
+describe('getWorkerDatabaseIndex', () => {
+  const original = process.env.VITEST_POOL_ID
+  afterEach(() => {
+    if (original === undefined) delete process.env.VITEST_POOL_ID
+    else process.env.VITEST_POOL_ID = original
+  })
+
+  it('maps the worker pool id into the database range', () => {
+    process.env.VITEST_POOL_ID = '3'
+    expect(getWorkerDatabaseIndex(256)).toBe(3)
+  })
+
+  it('wraps when the pool id exceeds the database count', () => {
+    process.env.VITEST_POOL_ID = '18'
+    expect(getWorkerDatabaseIndex(16)).toBe(2)
+  })
+
+  it("defaults to Redis's 16 databases", () => {
+    process.env.VITEST_POOL_ID = '20'
+    expect(getWorkerDatabaseIndex()).toBe(4)
+  })
+
+  it('falls back to index 0 when no worker id is set', () => {
+    delete process.env.VITEST_POOL_ID
+    expect(getWorkerDatabaseIndex(256)).toBe(0)
+  })
+})

--- a/packages/testcontainers/src/vitest/index.ts
+++ b/packages/testcontainers/src/vitest/index.ts
@@ -5,5 +5,47 @@
  * @packageDocumentation
  */
 
-// Implementation lands in DEVX-59; see the v1 API sketch on the map (DEVX-55).
-export {}
+import type { StartedNetwork } from 'testcontainers'
+
+import type { ContainerConfiguration } from '../config.js'
+import { serializeContainers, TESTCONTAINERS_ENV_KEY } from '../handoff.js'
+import { setup, teardown } from '../setup.js'
+
+/**
+ * Build a vitest `globalSetup` default export. The returned function starts the
+ * given containers, publishes their info to `process.env[TESTCONTAINERS_ENV_KEY]`
+ * for test files to read back via `getContainer`, and returns a teardown
+ * callback vitest runs after the suite.
+ *
+ * @example
+ * ```ts
+ * // tests/global-setup.ts
+ * import { postgres, redis } from '@opengovsg/starter-kitty-testcontainers'
+ * import { createGlobalSetup } from '@opengovsg/starter-kitty-testcontainers/vitest'
+ *
+ * export default createGlobalSetup([postgres(), redis({ databases: 256 })])
+ * ```
+ *
+ * @public
+ */
+export const createGlobalSetup =
+  (configurations: ContainerConfiguration[], options: { network?: StartedNetwork } = {}) =>
+  async (): Promise<() => Promise<void>> => {
+    const containers = await setup(configurations, options)
+    process.env[TESTCONTAINERS_ENV_KEY] = serializeContainers(containers)
+    return async () => {
+      delete process.env[TESTCONTAINERS_ENV_KEY]
+      await teardown(containers)
+    }
+  }
+
+/**
+ * Pick a Redis logical-DB index for the current vitest worker so parallel
+ * workers never share state. Computed as `VITEST_POOL_ID % databases`;
+ * `databases` defaults to Redis's built-in 16. Pair with a Redis started via
+ * `redis({ databases })` and have the app call `client.select(index)` plus
+ * `flushdb` itself (kept client-agnostic).
+ *
+ * @public
+ */
+export const getWorkerDatabaseIndex = (databases = 16): number => Number(process.env.VITEST_POOL_ID ?? 0) % databases


### PR DESCRIPTION
Implements the `/vitest` glue helpers ruled in by the [v1 API sketch](https://linear.app/ogp/document/opengovsgstarter-kitty-testcontainers-v1-api-sketch-701c897d073f), resolving [Implement vitest/playwright glue helpers (DEVX-59)](https://linear.app/ogp/issue/DEVX-59).

## What

- **`createGlobalSetup(configs, options?)`** - factory for a vitest `globalSetup` default export. Starts the containers via `setup`, publishes their info to `process.env[TESTCONTAINERS_ENV_KEY]`, and returns a teardown callback that clears the env and stops the containers.
- **`getWorkerDatabaseIndex(databases = 16)`** - pure `VITEST_POOL_ID % databases` helper for per-worker Redis logical-DB isolation. Client `select`/`flushdb` stays app-side (client-agnostic), matching the design.

Usage:

```ts
// tests/global-setup.ts
import { postgres, redis } from '@opengovsg/starter-kitty-testcontainers'
import { createGlobalSetup } from '@opengovsg/starter-kitty-testcontainers/vitest'

export default createGlobalSetup([postgres(), redis({ databases: 256 })])
```

## Tests

- Unit tests for `getWorkerDatabaseIndex` (pool id mapping, wrap, default 16, unset → 0).
- Docker-backed test that boots redis through the factory, checks the handoff is reachable over TCP, and verifies teardown clears the env.
- Full package suite: 27 passed. `lint`, `build`, `ci:report` green.

Only the `/vitest` entry changes; api-extractor analyzes the main entry, so `etc/*.api.md` is untouched. No changeset - version stays `0.0.0` until the publish ticket (DEVX-61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)