### PR TITLE
fix(validators): sync API report with webhook validator

### DIFF
--- a/etc/starter-kitty-validators.api.md
+++ b/etc/starter-kitty-validators.api.md
@@ -6,6 +6,7 @@
 
 /// <reference types="node" />
 
+import { URL as URL_2 } from 'url';
 import { z } from 'zod/v4';
 
 // @public
@@ -65,6 +66,28 @@ export interface UrlValidatorOptions {
     baseOrigin?: string;
     // Warning: (ae-forgotten-export) The symbol "UrlValidatorWhitelist" needs to be exported by the entry point index.d.ts
     whitelist?: UrlValidatorWhitelist;
+}
+
+// @public
+export const webhookUrlSchema: z.ZodPipe<z.ZodURL, z.ZodTransform<URL_2, string>>;
+
+// @public
+export class WebhookUrlValidationError extends Error {
+    constructor(message: string);
+}
+
+// @public
+export class WebhookUrlValidator {
+    constructor(options?: WebhookUrlValidatorOptions);
+    fetch(url: string | URL, init?: RequestInit): Promise<Response>;
+    validate(url: string | URL): URL;
+    validateAsync(url: string | URL): Promise<URL>;
+}
+
+// @public
+export interface WebhookUrlValidatorOptions {
+    // Warning: (ae-forgotten-export) The symbol "DnsLookupFn" needs to be exported by the entry point index.d.ts
+    lookup?: DnsLookupFn;
 }
 
 ```


### PR DESCRIPTION
## Summary
- `publish-docs` CI on `develop` was failing at the "Check API report" step
- Root cause: PR #92 (SSRF-safe webhook URL validator) added new exports (`webhookUrlSchema`, `WebhookUrlValidator`, `WebhookUrlValidationError`, `WebhookUrlValidatorOptions`) but never regenerated `etc/starter-kitty-validators.api.md`
- Regenerated the report locally via `api-extractor run --local` so it matches the current public API surface

## Test plan
- [x] `api-extractor run --verbose` (CI mode) reports "The API report is up to date"
- [x] `pnpm build` succeeds for `packages/validators`

Fixes the failure at https://github.com/opengovsg/starter-kitty/actions/runs/29808759027/job/88564895336