### PR TITLE
feat(rate-limit): custom rate limiter fallback values

### DIFF
--- a/.changeset/clamp-fallback-allowance.md
+++ b/.changeset/clamp-fallback-allowance.md
@@ -1,0 +1,5 @@
+---
+'@opengovsg/starter-kitty-rate-limit': minor
+---
+
+The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory. A new `fallback` option overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.

--- a/.changeset/clamp-fallback-allowance.md
+++ b/.changeset/clamp-fallback-allowance.md
@@ -1,8 +1,8 @@
 ---
-'@opengovsg/rate-limit': minor
+"@opengovsg/rate-limit": minor
 ---
 
-The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory. A new `fallback` option overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.
+The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory. A new `defaults.fallback` setting overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.
 
 Conditions that mean enforcement itself is degraded, no Redis client configured (the memory-only path) and an unexpected error escaping the in-memory insurance limiter, are now reported to `error` instead of `warn`, so they can be alerted on distinctly from routine configuration warnings (e.g. a clamped rate-limit value, which still goes to `warn`).
 

--- a/.changeset/clamp-fallback-allowance.md
+++ b/.changeset/clamp-fallback-allowance.md
@@ -2,6 +2,8 @@
 '@opengovsg/rate-limit': minor
 ---
 
+feat(rate-limit): allow custom rate limiter fallback values
+
 The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (5 points/second, 10 for `createGlobalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory.
 
 A new `overrides.fallback` setting overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.

--- a/.changeset/clamp-fallback-allowance.md
+++ b/.changeset/clamp-fallback-allowance.md
@@ -1,5 +1,9 @@
 ---
-'@opengovsg/starter-kitty-rate-limit': minor
+'@opengovsg/rate-limit': minor
 ---
 
 The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory. A new `fallback` option overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.
+
+Conditions that mean enforcement itself is degraded, no Redis client configured (the memory-only path) and an unexpected error escaping the in-memory insurance limiter, are now reported to `error` instead of `warn`, so they can be alerted on distinctly from routine configuration warnings (e.g. a clamped rate-limit value, which still goes to `warn`).
+
+Breaking for existing callers: the `Logger` interface now requires an `error` method alongside `warn`, so any custom logger passed as `logger` must implement both.

--- a/.changeset/clamp-fallback-allowance.md
+++ b/.changeset/clamp-fallback-allowance.md
@@ -2,7 +2,7 @@
 '@opengovsg/rate-limit': minor
 ---
 
-The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory.
+The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (5 points/second, 10 for `createGlobalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory.
 
 A new `overrides.fallback` setting overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.
 

--- a/.changeset/clamp-fallback-allowance.md
+++ b/.changeset/clamp-fallback-allowance.md
@@ -1,9 +1,9 @@
 ---
-"@opengovsg/rate-limit": minor
+'@opengovsg/rate-limit': minor
 ---
 
-The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory. A new `defaults.fallback` setting overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.
+The in-memory limiter used as insurance during a Redis outage, and as the sole limiter when no `client` is configured, now enforces a fixed fallback allowance (10 points/second, 5 for `createLocalRateLimiter`) instead of the primary `points`/`duration`, and grants nothing extra from burst while running off memory.
 
-Conditions that mean enforcement itself is degraded, no Redis client configured (the memory-only path) and an unexpected error escaping the in-memory insurance limiter, are now reported to `error` instead of `warn`, so they can be alerted on distinctly from routine configuration warnings (e.g. a clamped rate-limit value, which still goes to `warn`).
+A new `overrides.fallback` setting overrides the default. See [ADR 0010](https://github.com/opengovsg/starter-kitty/blob/develop/docs/adr/0010-clamp-insurance-limiter-fallback.md) for the rationale.
 
-Breaking for existing callers: the `Logger` interface now requires an `error` method alongside `warn`, so any custom logger passed as `logger` must implement both.
+Creating a limiter with no Redis client is now reported to `logger.error` instead of `logger.warn`, since enforcement in that mode is degraded. This makes it alertable distinctly from routine configuration warnings such as a clamped rate-limit value, which still go to `warn`.

--- a/apps/docs/examples/rate-limit.md
+++ b/apps/docs/examples/rate-limit.md
@@ -114,9 +114,16 @@ export const reportRateLimiter = createLocalRateLimiter({
   overrides: {
     points: 5,
     duration: 60,
+    fallback: { points: 5, duration: 60 },
+    prefix: 'reports',
   },
 })
 ```
+
+The nested fallback is the independent in-memory allowance used when Redis is
+unavailable. Omit it to use 10 points per second by default, or 5 points per
+second for `createLocalRateLimiter`. An override must provide both `points` and
+`duration`, and never receives extra burst capacity.
 
 ```javascript
 app.get('/api/reports', authenticate, rateLimited(reportRateLimiter), generateReport)

--- a/apps/docs/examples/rate-limit.md
+++ b/apps/docs/examples/rate-limit.md
@@ -114,16 +114,9 @@ export const reportRateLimiter = createLocalRateLimiter({
   overrides: {
     points: 5,
     duration: 60,
-    fallback: { points: 5, duration: 60 },
-    prefix: 'reports',
   },
 })
 ```
-
-The nested fallback is the independent in-memory allowance used when Redis is
-unavailable. Omit it to use 10 points per second by default, or 5 points per
-second for `createLocalRateLimiter`. An override must provide both `points` and
-`duration`, and never receives extra burst capacity.
 
 ```javascript
 app.get('/api/reports', authenticate, rateLimited(reportRateLimiter), generateReport)

--- a/apps/docs/examples/rate-limit.md
+++ b/apps/docs/examples/rate-limit.md
@@ -104,7 +104,8 @@ app.post('/api/submission', authenticate, rateLimited(localRateLimiter), createS
 ```
 
 Configuration is fixed at creation, so a route that needs different limits
-gets its own limiter:
+gets its own limiter. Naming limiters after their use case keeps every policy
+reviewable in one module:
 
 ```javascript
 // src/rate-limiters.ts
@@ -131,14 +132,20 @@ request logging. Do not accept forwarding headers from untrusted clients.
 Drive per-procedure limits from procedure `meta`, referencing a limiter
 instance:
 
-```javascript
+```typescript
+import type { LocalRateLimiter } from '@opengovsg/rate-limit'
 import { createLocalRateLimiter, RateLimitExceededError } from '@opengovsg/rate-limit'
 import { initTRPC, TRPCError } from '@trpc/server'
 
 import { localRateLimiter } from '~/rate-limiters'
 import { redis } from '~/redis'
 
-const t = initTRPC.context().meta().create()
+interface Meta {
+  // Defaults to `localRateLimiter`. Set to `null` to opt out of rate limiting.
+  rateLimiter?: LocalRateLimiter | null
+}
+
+const t = initTRPC.context().meta<Meta>().create()
 
 const rateLimitMiddleware = t.middleware(async ({ ctx, meta, path, next }) => {
   if (meta?.rateLimiter === null) return next() // opt-out per procedure
@@ -163,7 +170,7 @@ export const publicProcedure = t.procedure.use(rateLimitMiddleware)
 // Stricter limits where it matters: a dedicated limiter, referenced from meta.
 const otpRateLimiter = createLocalRateLimiter({
   client: redis,
-  overrides: { points: 5, duration: 60, burst: { points: 3, duration: 120 }, prefix: 'otp' },
+  overrides: { points: 5, duration: 60, burst: { points: 3, duration: 120 } },
 })
 
 const requestOtp = publicProcedure.meta({ rateLimiter: otpRateLimiter }).mutation(/* ... */)
@@ -173,8 +180,12 @@ const requestOtp = publicProcedure.meta({ rateLimiter: otpRateLimiter }).mutatio
 
 In the local rate limiter, `actor` is caller-defined. Use a stable identifier for the authenticated principal such as a user ID or an API-key ID.
 
-For bearer tokens, hash before keying
-so raw secrets never become store keys:
+When a request can carry more than one kind of identity, prefix the actor
+with its type, such as `userId:123` or `apiKey:123`, so different identity
+classes cannot share a bucket.
+
+Hash actors that are secrets or may contain PII, such as bearer tokens or
+email-based auth subjects, so raw values never become store keys:
 
 ```javascript
 import { createHash } from 'node:crypto'
@@ -182,3 +193,36 @@ import { createHash } from 'node:crypto'
 const actor = createHash('sha256').update(bearerToken).digest('hex')
 await localRateLimiter.check({ actor, resource: 'mcp.callTool' })
 ```
+
+## Custom keys
+
+`createRateLimiter` exposes the core limiter with a caller-supplied `key`,
+for work the global and local shapes do not fit, such as throttling a write
+to a hot database row:
+
+```javascript
+// src/rate-limiters.ts
+import { createRateLimiter } from '@opengovsg/rate-limit'
+
+/** At most one `lastUsedAt` write per API key every ten minutes. */
+export const apiKeyTouchRateLimiter = createRateLimiter({
+  client: redis,
+  logger,
+  overrides: { prefix: 'api-key-touch', points: 1, duration: 600, burst: null },
+})
+```
+
+```javascript
+async function touchLastUsed(keyId) {
+  // Best-effort: a throttled window or a limiter error skips the write.
+  try {
+    await apiKeyTouchRateLimiter.check({ key: keyId })
+  } catch {
+    return
+  }
+  await db.apiKey.update({ where: { id: keyId }, data: { lastUsedAt: new Date() } })
+}
+```
+
+Keys are used verbatim, so normalize or hash caller-controlled values before
+keying.

--- a/docs/adr/0010-clamp-insurance-limiter-fallback.md
+++ b/docs/adr/0010-clamp-insurance-limiter-fallback.md
@@ -71,8 +71,6 @@ overrides?: {
 Omitting `fallback` uses the factory's fallback constant. An override must
 provide both `points` and `duration`.
 
-The configuration is factory-level only. There is no per-check override.
-
 ## Consequences
 
 - During a Redis outage, an N-replica deployment's effective limit per

--- a/docs/adr/0010-clamp-insurance-limiter-fallback.md
+++ b/docs/adr/0010-clamp-insurance-limiter-fallback.md
@@ -5,92 +5,57 @@ Status: Accepted (amends [0009](./0009-rate-limit-package-design.md))
 
 ## Context
 
-[ADR 0009](./0009-rate-limit-package-design.md) establishes that an in-memory
-limiter is always present, in two roles: as the `insuranceLimiter` behind each
-Redis-backed window during an outage, and as the sole enforcement when no
-`client` is configured at all. In both roles, the memory limiter is built with
-the same `points`/`duration` as the primary configuration.
+[ADR 0009](./0009-rate-limit-package-design.md) gives the in-memory limiter
+two roles: insurance behind each Redis-backed window during an outage, and
+the sole enforcement when no `client` is configured. In both roles it is
+built with the same `points` and `duration` as the primary window.
 
-That equivalence has a consequence 0009 names but doesn't correct: because the
-memory limiter is per-instance, a deployment running N replicas effectively
-multiplies its rate limit by N the moment Redis becomes unavailable — every
-replica enforces the full configured window independently, with no shared
-counter. A limiter is most likely to matter exactly when a service is under
-elevated load or attack, which is also when Redis is more likely to be
-degraded (contention, failover, network partition). Reusing the primary
-allowance for the fallback path means the limiter gets *more* permissive
-exactly when the system is least able to afford it.
+The memory limiter is per-instance, so a deployment with N replicas
+multiplies its limit by N the moment Redis goes down. An outage is also when
+a service is most likely to be under pressure.
 
-The same reasoning applies to the memory-only path (no `client` configured at
-all): that configuration is not shared across replicas either, and is equally
-unfit to carry a production-sized allowance per instance.
+Reusing the primary allowance makes the limiter more permissive exactly when
+the system can least support it.
 
 ## Decision
 
-### The fallback allowance defaults to 10 points/second, 5 for the local limiter
+### The fallback allowance is a fixed constant, 10/s or 5/s
 
-Every memory limiter this package builds — the insurance limiter behind each
-Redis-backed window, and the sole limiter when no `client` is configured —
-uses a clamped **fallback** configuration instead of the primary `points`/
-`duration`. Rather than deriving the fallback from whatever primary
-`points`/`duration` a caller happens to configure, it is a small, fixed set of
-constants, one per factory:
+The insurance limiter behind each Redis-backed window, and the sole limiter
+when no `client` is configured, use a fixed fallback allowance instead of
+the primary `points` and `duration`:
 
-- `createRateLimiter` (bare) and `createGlobalRateLimiter`: **10 points per
-  second**. The global limiter's own primary default is 100/s, so this is a
-  deliberate 10x tightening during an outage.
-- `createLocalRateLimiter`: **5 points per second**, overriding the base 10/s
-  down to match its own ~5 rps steady default, so the fallback path isn't
-  needlessly looser than the local limiter's already-conservative baseline in
-  the common case.
+- **`createRateLimiter` and `createGlobalRateLimiter`: 10 points per
+  second.** The global limiter's primary default is 100/s, so an outage
+  tightens it 10x.
+- **`createLocalRateLimiter`: 5 points per second.** This matches its own
+  roughly 5 rps steady default. The base 10/s would be looser than normal
+  operation.
 
-Fixed constants are simpler to reason about and implement than deriving the
-fallback from the resolved primary window: no computation, no rounding rules,
-one number (or two) to remember. The trade-off is that they don't
-automatically track a caller's own tightening. A caller who configures a
-much stricter primary window than the relevant constant above — e.g. a
-per-route override on the local limiter such as
-`{ points: 5, duration: 60 }` (~0.08 rps), well under the local limiter's 5/s
-fallback — will see the fallback path be *more lenient* than that route's own
-primary configuration during a degraded state. This is an accepted trade-off:
-callers with such tightly-scoped routes set `fallback` explicitly (see below)
-alongside the per-check override if they need the fallback to track it.
+A fixed constant is simpler to reason about than a fallback derived from the
+primary window. The trade-off is that a caller with a primary window tighter
+than the constant, such as a per-route override of
+`{ points: 5, duration: 60 }`, gets a fallback more lenient than that
+route's normal enforcement. Such callers should set `fallback` explicitly
+(see below).
 
 ### Burst is disabled while running in fallback
 
-Bursting exists to be lenient — it absorbs legitimate spikes on top of an
-already-permissive steady window. That is the opposite of what a degraded,
-possibly-under-attack path should do, so burst grants nothing extra whenever
-enforcement is running off memory, regardless of whether the primary
-configuration has a `burst` window.
+The burst limiter exists to soak up spikes. When the system is degraded, a
+spike is more likely to hurt it, so no burst allowance applies when Redis is
+not available.
 
-This isn't free: `BurstyRateLimiter` (from `rate-limiter-flexible`) only
-consults its burst leg when the steady leg *rejects*, and each leg's
-`insuranceLimiter` is only ever consulted when that leg's own Redis call
-throws an infrastructure error, never on an ordinary over-limit rejection. A
-naive implementation would leave the burst window's insurance limiter
-configured with the primary's full, unclamped burst allowance, which would
-grant its whole burst window on top of the clamped steady fallback during an
-outage, undermining the entire premise of this ADR.
+When no `client` is configured, the fallback is a plain in-memory limiter
+with no burst leg.
 
-The burst window's insurance limiter is therefore built as a dedicated,
-zero-capacity memory limiter (`points: 0`, a valid finite value the
-underlying library accepts): it rejects immediately and cleanly with a
-`RateLimiterRes` whenever it's asked to consume, so a caller who exceeds the
-clamped steady fallback during an outage still gets an ordinary
-`RateLimitExceededError`, never a raw infrastructure error. This limiter sits
-completely inert whenever Redis is healthy, since insurance is consulted only
-on infra failure, never on a legitimate rejection.
+When Redis is configured, the burst leg's insurance is an in-memory limiter
+with `points: 0`. A caller who exceeds the steady fallback during an outage
+then still gets `RateLimitExceededError` rather than a Redis error.
 
-An alternative considered was pointing the burst leg's insurance at the same
-memory limiter instance used for the steady fallback, so both legs draw from
-one shared bucket. That was rejected: on every rejected request during an
-outage, the steady leg would consume from the shared bucket, then the burst
-leg would consume from it again on retry, double-counting against a bucket
-that's already over limit. The dedicated zero-capacity limiter avoids that
-without depending on call-order coincidences.
+> Alerting when enforcement is running on the insurance limiter is deferred to
+> a future ADR.
 
-### A `fallback` option, narrower than `RateLimitConfig`
+### Configuration using a fallback option
 
 `CreateRateLimiterOptions` gains:
 
@@ -101,60 +66,24 @@ fallback?: {
 }
 ```
 
-Values given here override the factory's built-in fallback constant the same
-way `defaults` already overrides `BASE_DEFAULTS`: set only `points` to keep
-the default duration, only `duration` to keep the default points, or both.
+Values here override the factory's fallback constant the same way `defaults`
+overrides the built-in defaults.
 
-The type is deliberately narrower than `RateLimitConfig` — no `burst`, no
-`prefix`. Excluding `burst` from the type makes it structurally impossible to
-reintroduce burst leniency into the fallback path by passing a config
-object. The only way to loosen it is to raise `fallback.points` explicitly,
-which is a visible, intentional choice at the call site. `prefix` isn't
-meaningful here: the fallback limiter shares the primary window's key
-namespace, since it stands in for the same window rather than a separate one.
-
-This is a factory-level option only, not exposed per-check. Per-check
-`options` already exist to express a route's *primary* window. The fallback
-behaviour is a property of how conservatively the factory degrades, which
-argues for one answer per factory rather than one that could silently vary
-by call site.
+The option is factory-level only. There is no per-check override.
 
 ## Consequences
 
-- An N-replica deployment's effective rate limit during a Redis outage is
-  bounded by roughly `N × 10/s` (`N × 5/s` for the local limiter) per window
-  instead of `N × points`, per the threat model in
-  [ADR 0009](./0009-rate-limit-package-design.md#threat-model-single-source-floods-only):
-  a degraded system should assume it's more likely to be under attack, not
-  less. The global limiter's 100/s default sees a real, material tightening
-  (10x) during an outage.
-- Because the fallback is a fixed constant rather than derived from the
-  resolved primary window, a caller whose primary configuration is already
-  tighter than the relevant constant (e.g. a per-route override well under
-  5 or 10 rps) will see the fallback path be *more lenient* than that route's
-  own normal enforcement during a degraded state. This is a known, accepted
-  trade-off of picking simple fixed numbers over a derived cap. Such callers
-  set `fallback` explicitly if they need the fallback to track their tighter
-  primary.
-- The memory-only deployment mode (no `client` configured) is now subject to
-  the same fixed fallback constants, and stops reflecting whatever `points`/
-  `duration` a caller configured. This lands hardest on the exact scenario
-  0009 recommends this mode for: tests and local development, where a small
-  configured `points` value (e.g. `points: 1` to make a test deterministic)
-  no longer bounds enforcement at all once no `client` is passed — the
-  fallback constant does. Callers who need memory-only enforcement to match
-  a specific configured value (test assertions included) must pass
-  `fallback` explicitly rather than relying on `points`/`duration` alone.
-  This is treated as a correction, not a backwards-compatibility concern,
-  since 0009 already documents this mode as unfit for shared, replica-safe
-  production use, but it is a real, deliberate ergonomics cost accepted here
-  rather than an oversight.
-- Bursty configurations lose their burst allowance entirely while degraded.
-  Callers relying on burst to absorb legitimate spikes will see 429s sooner
-  than before during an outage. This is the intended trade-off: a tighter
-  steady-only fallback beats a fallback that's accidentally as lenient as
-  the primary window.
-- Consumers who've measured their own replica count, or configured a
-  primary window far tighter than the built-in fallback constant, can
-  express an exact fallback figure via the new `fallback` option, without
-  reaching for `RateLimitConfig`'s full shape.
+- During a Redis outage, an N-replica deployment's effective limit per
+  window is bounded by roughly N × 10/s (N × 5/s for the local limiter)
+  instead of N × the primary points.
+- A caller whose primary window is tighter than the fallback constant gets a
+  more lenient fallback while degraded, and must set `fallback` explicitly
+  to track it.
+- The memory-only mode (no `client`) stops reflecting the configured
+  `points` and `duration`. Tests that rely on a small `points` value must
+  pass `fallback` explicitly. This is a correction, since 0009 already
+  documents this mode as unfit for replica-safe production use.
+- Bursty configurations lose their burst allowance while degraded, so
+  callers see 429s sooner during an outage.
+- Callers who know their replica count can set an exact figure via
+  `fallback`.

--- a/docs/adr/0010-clamp-insurance-limiter-fallback.md
+++ b/docs/adr/0010-clamp-insurance-limiter-fallback.md
@@ -1,0 +1,160 @@
+# 10. Clamp the insurance limiter's fallback allowance
+
+Date: 2026-07-22
+Status: Accepted (amends [0009](./0009-rate-limit-package-design.md))
+
+## Context
+
+[ADR 0009](./0009-rate-limit-package-design.md) establishes that an in-memory
+limiter is always present, in two roles: as the `insuranceLimiter` behind each
+Redis-backed window during an outage, and as the sole enforcement when no
+`client` is configured at all. In both roles, the memory limiter is built with
+the same `points`/`duration` as the primary configuration.
+
+That equivalence has a consequence 0009 names but doesn't correct: because the
+memory limiter is per-instance, a deployment running N replicas effectively
+multiplies its rate limit by N the moment Redis becomes unavailable — every
+replica enforces the full configured window independently, with no shared
+counter. A limiter is most likely to matter exactly when a service is under
+elevated load or attack, which is also when Redis is more likely to be
+degraded (contention, failover, network partition). Reusing the primary
+allowance for the fallback path means the limiter gets *more* permissive
+exactly when the system is least able to afford it.
+
+The same reasoning applies to the memory-only path (no `client` configured at
+all): that configuration is not shared across replicas either, and is equally
+unfit to carry a production-sized allowance per instance.
+
+## Decision
+
+### The fallback allowance defaults to 10 points/second, 5 for the local limiter
+
+Every memory limiter this package builds — the insurance limiter behind each
+Redis-backed window, and the sole limiter when no `client` is configured —
+uses a clamped **fallback** configuration instead of the primary `points`/
+`duration`. Rather than deriving the fallback from whatever primary
+`points`/`duration` a caller happens to configure, it is a small, fixed set of
+constants, one per factory:
+
+- `createRateLimiter` (bare) and `createGlobalRateLimiter`: **10 points per
+  second**. The global limiter's own primary default is 100/s, so this is a
+  deliberate 10x tightening during an outage.
+- `createLocalRateLimiter`: **5 points per second**, overriding the base 10/s
+  down to match its own ~5 rps steady default, so the fallback path isn't
+  needlessly looser than the local limiter's already-conservative baseline in
+  the common case.
+
+Fixed constants are simpler to reason about and implement than deriving the
+fallback from the resolved primary window: no computation, no rounding rules,
+one number (or two) to remember. The trade-off is that they don't
+automatically track a caller's own tightening. A caller who configures a
+much stricter primary window than the relevant constant above — e.g. a
+per-route override on the local limiter such as
+`{ points: 5, duration: 60 }` (~0.08 rps), well under the local limiter's 5/s
+fallback — will see the fallback path be *more lenient* than that route's own
+primary configuration during a degraded state. This is an accepted trade-off:
+callers with such tightly-scoped routes set `fallback` explicitly (see below)
+alongside the per-check override if they need the fallback to track it.
+
+### Burst is disabled while running in fallback
+
+Bursting exists to be lenient — it absorbs legitimate spikes on top of an
+already-permissive steady window. That is the opposite of what a degraded,
+possibly-under-attack path should do, so burst grants nothing extra whenever
+enforcement is running off memory, regardless of whether the primary
+configuration has a `burst` window.
+
+This isn't free: `BurstyRateLimiter` (from `rate-limiter-flexible`) only
+consults its burst leg when the steady leg *rejects*, and each leg's
+`insuranceLimiter` is only ever consulted when that leg's own Redis call
+throws an infrastructure error, never on an ordinary over-limit rejection. A
+naive implementation would leave the burst window's insurance limiter
+configured with the primary's full, unclamped burst allowance, which would
+grant its whole burst window on top of the clamped steady fallback during an
+outage, undermining the entire premise of this ADR.
+
+The burst window's insurance limiter is therefore built as a dedicated,
+zero-capacity memory limiter (`points: 0`, a valid finite value the
+underlying library accepts): it rejects immediately and cleanly with a
+`RateLimiterRes` whenever it's asked to consume, so a caller who exceeds the
+clamped steady fallback during an outage still gets an ordinary
+`RateLimitExceededError`, never a raw infrastructure error. This limiter sits
+completely inert whenever Redis is healthy, since insurance is consulted only
+on infra failure, never on a legitimate rejection.
+
+An alternative considered was pointing the burst leg's insurance at the same
+memory limiter instance used for the steady fallback, so both legs draw from
+one shared bucket. That was rejected: on every rejected request during an
+outage, the steady leg would consume from the shared bucket, then the burst
+leg would consume from it again on retry, double-counting against a bucket
+that's already over limit. The dedicated zero-capacity limiter avoids that
+without depending on call-order coincidences.
+
+### A `fallback` option, narrower than `RateLimitConfig`
+
+`CreateRateLimiterOptions` gains:
+
+```ts
+fallback?: {
+  points?: number
+  duration?: number
+}
+```
+
+Values given here override the factory's built-in fallback constant the same
+way `defaults` already overrides `BASE_DEFAULTS`: set only `points` to keep
+the default duration, only `duration` to keep the default points, or both.
+
+The type is deliberately narrower than `RateLimitConfig` — no `burst`, no
+`prefix`. Excluding `burst` from the type makes it structurally impossible to
+reintroduce burst leniency into the fallback path by passing a config
+object. The only way to loosen it is to raise `fallback.points` explicitly,
+which is a visible, intentional choice at the call site. `prefix` isn't
+meaningful here: the fallback limiter shares the primary window's key
+namespace, since it stands in for the same window rather than a separate one.
+
+This is a factory-level option only, not exposed per-check. Per-check
+`options` already exist to express a route's *primary* window. The fallback
+behaviour is a property of how conservatively the factory degrades, which
+argues for one answer per factory rather than one that could silently vary
+by call site.
+
+## Consequences
+
+- An N-replica deployment's effective rate limit during a Redis outage is
+  bounded by roughly `N × 10/s` (`N × 5/s` for the local limiter) per window
+  instead of `N × points`, per the threat model in
+  [ADR 0009](./0009-rate-limit-package-design.md#threat-model-single-source-floods-only):
+  a degraded system should assume it's more likely to be under attack, not
+  less. The global limiter's 100/s default sees a real, material tightening
+  (10x) during an outage.
+- Because the fallback is a fixed constant rather than derived from the
+  resolved primary window, a caller whose primary configuration is already
+  tighter than the relevant constant (e.g. a per-route override well under
+  5 or 10 rps) will see the fallback path be *more lenient* than that route's
+  own normal enforcement during a degraded state. This is a known, accepted
+  trade-off of picking simple fixed numbers over a derived cap. Such callers
+  set `fallback` explicitly if they need the fallback to track their tighter
+  primary.
+- The memory-only deployment mode (no `client` configured) is now subject to
+  the same fixed fallback constants, and stops reflecting whatever `points`/
+  `duration` a caller configured. This lands hardest on the exact scenario
+  0009 recommends this mode for: tests and local development, where a small
+  configured `points` value (e.g. `points: 1` to make a test deterministic)
+  no longer bounds enforcement at all once no `client` is passed — the
+  fallback constant does. Callers who need memory-only enforcement to match
+  a specific configured value (test assertions included) must pass
+  `fallback` explicitly rather than relying on `points`/`duration` alone.
+  This is treated as a correction, not a backwards-compatibility concern,
+  since 0009 already documents this mode as unfit for shared, replica-safe
+  production use, but it is a real, deliberate ergonomics cost accepted here
+  rather than an oversight.
+- Bursty configurations lose their burst allowance entirely while degraded.
+  Callers relying on burst to absorb legitimate spikes will see 429s sooner
+  than before during an outage. This is the intended trade-off: a tighter
+  steady-only fallback beats a fallback that's accidentally as lenient as
+  the primary window.
+- Consumers who've measured their own replica count, or configured a
+  primary window far tighter than the built-in fallback constant, can
+  express an exact fallback figure via the new `fallback` option, without
+  reaching for `RateLimitConfig`'s full shape.

--- a/docs/adr/0010-clamp-insurance-limiter-fallback.md
+++ b/docs/adr/0010-clamp-insurance-limiter-fallback.md
@@ -36,7 +36,7 @@ A fixed constant is simpler to reason about than a fallback derived from the
 primary window. The trade-off is that a caller with a primary window tighter
 than the constant, such as a per-route override of
 `{ points: 5, duration: 60 }`, gets a fallback more lenient than that
-route's normal enforcement. Such callers should set `defaults.fallback`
+route's normal enforcement. Such callers should set `overrides.fallback`
 explicitly (see below).
 
 ### Burst is disabled while running in fallback
@@ -57,10 +57,10 @@ then still gets `RateLimitExceededError` rather than a Redis error.
 
 ### Configuration using a nested fallback option
 
-`RateLimitConfig`, passed through `CreateRateLimiterOptions.defaults`, gains:
+`RateLimitConfig`, passed through `CreateRateLimiterOptions.overrides`, gains:
 
 ```ts
-defaults?: {
+overrides?: {
   fallback?: {
     points: number
     duration: number
@@ -79,13 +79,13 @@ The configuration is factory-level only. There is no per-check override.
   window is bounded by roughly N × 10/s (N × 5/s for the local limiter)
   instead of N × the primary points.
 - A caller whose primary window is tighter than the fallback constant gets a
-  more lenient fallback while degraded, and must set `defaults.fallback`
+  more lenient fallback while degraded, and must set `overrides.fallback`
   explicitly to track it.
 - The memory-only mode (no `client`) stops reflecting the configured
   `points` and `duration`. Tests that rely on a small `points` value must
-  pass `defaults.fallback` explicitly. This is a correction, since 0009 already
+  pass `overrides.fallback` explicitly. This is a correction, since 0009 already
   documents this mode as unfit for replica-safe production use.
 - Bursty configurations lose their burst allowance while degraded, so
   callers see 429s sooner during an outage.
 - Callers who know their replica count can set an exact figure via
-  `defaults.fallback`.
+  `overrides.fallback`.

--- a/docs/adr/0010-clamp-insurance-limiter-fallback.md
+++ b/docs/adr/0010-clamp-insurance-limiter-fallback.md
@@ -36,8 +36,8 @@ A fixed constant is simpler to reason about than a fallback derived from the
 primary window. The trade-off is that a caller with a primary window tighter
 than the constant, such as a per-route override of
 `{ points: 5, duration: 60 }`, gets a fallback more lenient than that
-route's normal enforcement. Such callers should set `fallback` explicitly
-(see below).
+route's normal enforcement. Such callers should set `defaults.fallback`
+explicitly (see below).
 
 ### Burst is disabled while running in fallback
 
@@ -55,21 +55,23 @@ then still gets `RateLimitExceededError` rather than a Redis error.
 > Alerting when enforcement is running on the insurance limiter is deferred to
 > a future ADR.
 
-### Configuration using a fallback option
+### Configuration using a nested fallback option
 
-`CreateRateLimiterOptions` gains:
+`RateLimitConfig`, passed through `CreateRateLimiterOptions.defaults`, gains:
 
 ```ts
-fallback?: {
-  points?: number
-  duration?: number
+defaults?: {
+  fallback?: {
+    points: number
+    duration: number
+  }
 }
 ```
 
-Values here override the factory's fallback constant the same way `defaults`
-overrides the built-in defaults.
+Omitting `fallback` uses the factory's fallback constant. An override must
+provide both `points` and `duration`.
 
-The option is factory-level only. There is no per-check override.
+The configuration is factory-level only. There is no per-check override.
 
 ## Consequences
 
@@ -77,13 +79,13 @@ The option is factory-level only. There is no per-check override.
   window is bounded by roughly N × 10/s (N × 5/s for the local limiter)
   instead of N × the primary points.
 - A caller whose primary window is tighter than the fallback constant gets a
-  more lenient fallback while degraded, and must set `fallback` explicitly
-  to track it.
+  more lenient fallback while degraded, and must set `defaults.fallback`
+  explicitly to track it.
 - The memory-only mode (no `client`) stops reflecting the configured
   `points` and `duration`. Tests that rely on a small `points` value must
-  pass `fallback` explicitly. This is a correction, since 0009 already
+  pass `defaults.fallback` explicitly. This is a correction, since 0009 already
   documents this mode as unfit for replica-safe production use.
 - Bursty configurations lose their burst allowance while degraded, so
   callers see 429s sooner during an outage.
 - Callers who know their replica count can set an exact figure via
-  `fallback`.
+  `defaults.fallback`.

--- a/docs/adr/0010-clamp-insurance-limiter-fallback.md
+++ b/docs/adr/0010-clamp-insurance-limiter-fallback.md
@@ -25,12 +25,13 @@ The insurance limiter behind each Redis-backed window, and the sole limiter
 when no `client` is configured, use a fixed fallback allowance instead of
 the primary `points` and `duration`:
 
-- **`createRateLimiter` and `createGlobalRateLimiter`: 10 points per
-  second.** The global limiter's primary default is 100/s, so an outage
-  tightens it 10x.
-- **`createLocalRateLimiter`: 5 points per second.** This matches its own
-  roughly 5 rps steady default. The base 10/s would be looser than normal
-  operation.
+- **`createGlobalRateLimiter`: 10 points per second.** The global limiter's
+  primary default is 100/s, so an outage tightens it 10x. The global rate
+  limit was permissive by default, and so it is tightened significantly when
+  the system is degraded.
+- **`createRateLimiter` and `createLocalRateLimiter`: 5 points per second.**
+  This matches their shared roughly 5 rps steady default. A looser fallback
+  would be more permissive than normal operation.
 
 A fixed constant is simpler to reason about than a fallback derived from the
 primary window. The trade-off is that a caller with a primary window tighter
@@ -74,7 +75,7 @@ provide both `points` and `duration`.
 ## Consequences
 
 - During a Redis outage, an N-replica deployment's effective limit per
-  window is bounded by roughly N × 10/s (N × 5/s for the local limiter)
+  window is bounded by roughly N × 5/s (N × 10/s for the global limiter)
   instead of N × the primary points.
 - A caller whose primary window is tighter than the fallback constant gets a
   more lenient fallback while degraded, and must set `overrides.fallback`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,4 +18,5 @@ Files are numbered sequentially: `NNNN-kebab-case-title.md`.
 | [0006](./0006-pluggable-error-serialization.md) | Pluggable error serialisation; no error type | Accepted |
 | [0007](./0007-fixed-shape-audit-helpers.md)     | Fixed-shape audit helpers                    | Accepted (amended by [0008](./0008-audit-lines-compose-scoped-context.md)) |
 | [0008](./0008-audit-lines-compose-scoped-context.md) | Audit lines compose scoped context      | Accepted |
-| [0009](./0009-rate-limit-package-design.md)     | Rate-limit package design                    | Accepted |
+| [0009](./0009-rate-limit-package-design.md)     | Rate-limit package design                    | Accepted (amended by [0010](./0010-clamp-insurance-limiter-fallback.md)) |
+| [0010](./0010-clamp-insurance-limiter-fallback.md) | Clamp the insurance limiter's fallback allowance | Accepted |

--- a/etc/rate-limit.api.md
+++ b/etc/rate-limit.api.md
@@ -32,15 +32,14 @@ export const createRateLimiter: (options: CreateRateLimiterOptions) => RateLimit
 // @public
 export interface CreateRateLimiterOptions {
     client?: RedisClient | null;
-    fallback?: FallbackConfig;
     logger: Logger;
     overrides?: RateLimitConfig;
 }
 
 // @public
 export interface FallbackConfig {
-    duration?: number;
-    points?: number;
+    duration: number;
+    points: number;
 }
 
 // @public
@@ -83,6 +82,7 @@ export const normalizeIp: (ip: string) => string | null;
 export interface RateLimitConfig {
     burst?: BurstConfig | null;
     duration?: number;
+    fallback?: FallbackConfig;
     points?: number;
     prefix?: string;
 }

--- a/etc/rate-limit.api.md
+++ b/etc/rate-limit.api.md
@@ -32,8 +32,15 @@ export const createRateLimiter: (options: CreateRateLimiterOptions) => RateLimit
 // @public
 export interface CreateRateLimiterOptions {
     client?: RedisClient | null;
+    fallback?: FallbackConfig;
     logger: Logger;
     overrides?: RateLimitConfig;
+}
+
+// @public
+export interface FallbackConfig {
+    duration?: number;
+    points?: number;
 }
 
 // @public

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -3,9 +3,9 @@
 A framework-agnostic rate-limiting core built on
 [rate-limiter-flexible](https://github.com/animir/node-rate-limiter-flexible).
 Counters live in an injected Redis ([ioredis](https://github.com/redis/ioredis))
-client so limits are shared across replicas, with an in-memory insurance
-limiter keeping enforcement alive through Redis outages — and a memory-only
-fallback when no client is configured at all.
+client so limits are shared across replicas. An in-memory insurance limiter
+keeps enforcement alive through Redis outages, and the limiter runs
+memory-only when no client is configured at all.
 
 The package reads **no environment variables** of its own and depends on no
 HTTP framework. `ioredis` is an optional peer dependency. Install it only if
@@ -43,8 +43,10 @@ export const globalRateLimiter = createGlobalRateLimiter({ client: redis, logger
 export const localRateLimiter = createLocalRateLimiter({ client: redis, logger })
 ```
 
-When `client` is omitted, the limiter runs on in-memory counters. This is suitable for tests and local development. However, as limits are
-per-instance and not shared across replicas, this is not suitable for a production use case.
+When `client` is omitted, the limiter runs on in-memory counters at the
+`fallback` allowance, not the steady limits. This is suitable for tests and
+local development. However, as limits are per-instance and not shared across
+replicas, it is not suitable for production.
 
 ## Checking limits
 
@@ -58,8 +60,8 @@ await localRateLimiter.check({
   // A normalized route identity (route template or procedure name), never
   // the raw URL: raw URLs give every parameter value its own bucket.
   resource: 'bookings.create',
-  // Optional request-scoped logger: request diagnostics (an unexpected store
-  // error) then carry this request's identity.
+  // Optional request-scoped logger so request diagnostics (an unexpected
+  // store error) carry this request's identity.
   logger: req.log,
 })
 ```
@@ -69,7 +71,7 @@ on the deployment's trusted-proxy configuration. Pass the same trusted value
 your app uses for request logging. Do not accept forwarding headers from
 untrusted clients.
 
-`actor` is caller-defined: a user ID, an API-key ID. `check` throws
+`actor` is caller-defined: a user ID or an API-key ID. `check` throws
 `RateLimitExceededError` when the allowance is exhausted. Any other error is
 reported via the per-call `logger`'s `error` method (falling back to the
 factory `logger`) and rethrown, so failing open or closed stays your decision.
@@ -97,15 +99,32 @@ and `toHttpHeaders` instead.
 
 ## Configuration
 
-Every limiter accepts `overrides` of shape:
+Every limiter accepts `overrides` of the shape below. Defaults shown are for
+`createRateLimiter`:
 
-| Field      | Default                                          | Meaning                                                                           |
-| ---------- | ------------------------------------------------ | --------------------------------------------------------------------------------- |
-| `points`   | `50`                                             | Consumption points per steady window                                              |
-| `duration` | `10`                                             | Steady window in seconds                                                          |
-| `burst`    | `{ points: 20, duration: 30 }`                   | Extra short-lived allowance; omit to inherit, `null` to disable                   |
-| `fallback` | `{ points: 5, duration: 1 }` (`10/1` for global) | Independent in-memory allowance, with burst granting nothing extra while degraded |
-| `prefix`   | `'api'` / `'global'` / `'local'`                 | Namespace segment isolating this limiter's counters in the shared store           |
+| Field      | Default                        | Meaning                                                                 |
+| ---------- | ------------------------------ | ----------------------------------------------------------------------- |
+| `points`   | `50`                           | Consumption points per steady window                                    |
+| `duration` | `10`                           | Steady window in seconds                                                |
+| `burst`    | `{ points: 20, duration: 30 }` | Extra short-lived allowance, `null` to disable                          |
+| `fallback` | `{ points: 5, duration: 1 }`   | Independent in-memory allowance while degraded                          |
+| `prefix`   | `'api'`                        | Namespace segment isolating this limiter's counters in the shared store |
+
+`createGlobalRateLimiter` changes every default:
+
+| Field      | Default                       |
+| ---------- | ----------------------------- |
+| `points`   | `100`                         |
+| `duration` | `1`                           |
+| `burst`    | `null`                        |
+| `fallback` | `{ points: 10, duration: 1 }` |
+| `prefix`   | `'global'`                    |
+
+`createLocalRateLimiter` changes only the prefix:
+
+| Field    | Default   |
+| -------- | --------- |
+| `prefix` | `'local'` |
 
 Configuration is fixed at creation. A route that needs different limits
 creates its own limiter with its own `overrides`.
@@ -123,10 +142,8 @@ const reportRateLimiter = createLocalRateLimiter({
 })
 ```
 
-Fallback is independent of the primary window. Omit `fallback` to use the
-factory default: 5 points per second for the base and local limiters, or 10
-points per second for the global limiter. An override must provide both
-`points` and `duration`.
+Fallback is independent of the primary window. Omit `fallback` to keep the
+factory default. An override must provide both `points` and `duration`.
 
 Store keys live under `rate-limit:<prefix>:` (steady) and
 `rate-limit-burst:<prefix>:` (burst).

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -43,8 +43,24 @@ export const globalRateLimiter = createGlobalRateLimiter({ client: redis, logger
 export const localRateLimiter = createLocalRateLimiter({ client: redis, logger })
 ```
 
-When `client` is omitted, the limiter runs on in-memory counters. This is suitable for tests and local development. However, as limits are
-per-instance and not shared across replicas, this is not suitable for a production use case.
+The global limiter validates and normalizes IP addresses by default. If the
+application already supplies a trusted, canonical key, pass
+`skipKeyNormalization: true` to use the string verbatim. This also disables
+IPv6 /64 bucketing and IPv4-mapped normalization, so do not use it with
+attacker-controlled or unnormalized values.
+
+The factory `logger`'s `error` fires when no Redis client is configured, since
+enforcement is then degraded (per-instance, not shared across replicas), not
+just misconfigured. `warn` fires whenever a rate-limit value is clamped to a
+safe integer (out of range, or a fractional value truncated toward zero),
+reporting the field's original and clamped values. Both fire once when the
+limiter is created, so a base/system logger fits. A Redis error that escapes
+the in-memory insurance limiter is a separate, per-request `error` (see
+[Checking limits](#checking-limits)).
+
+Without a `client`, limits are enforced in memory — functional, but
+per-instance and not shared across replicas. The factory `logger`'s `error`
+surfaces that trade-off.
 
 ## Checking limits
 
@@ -58,8 +74,8 @@ await localRateLimiter.check({
   // A normalized route identity (route template or procedure name), never
   // the raw URL: raw URLs give every parameter value its own bucket.
   resource: 'bookings.create',
-  // Optional request-scoped logger: request errors (an unexpected store
-  // error) then carry this request's identity.
+  // Optional request-scoped logger: request diagnostics (an unexpected store
+  // error, reported to `error`) then carry this request's identity.
   logger: req.log,
 })
 ```

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -115,15 +115,34 @@ and `toHttpHeaders` instead.
 
 Every limiter accepts `overrides` of shape:
 
-| Field      | Default                          | Meaning                                                                 |
-| ---------- | -------------------------------- | ----------------------------------------------------------------------- |
-| `points`   | `50`                             | Consumption points per steady window                                    |
-| `duration` | `10`                             | Steady window in seconds                                                |
-| `burst`    | `{ points: 20, duration: 30 }`   | Extra short-lived allowance (omit to inherit, `null` to disable)        |
-| `prefix`   | `'api'` / `'global'` / `'local'` | Namespace segment isolating this limiter's counters in the shared store |
+| Field      | Default                                         | Meaning                                                                    |
+| ---------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| `points`   | `50`                                            | Consumption points per steady window                                       |
+| `duration` | `10`                                            | Steady window in seconds                                                   |
+| `burst`    | `{ points: 20, duration: 30 }`                  | Extra short-lived allowance; omit to inherit, `null` to disable            |
+| `fallback` | `{ points: 10, duration: 1 }` (`5/1` for local) | Independent in-memory allowance; burst grants nothing extra while degraded |
+| `prefix`   | `'api'` / `'global'` / `'local'`                | Namespace segment isolating this limiter's counters in the shared store    |
 
 Configuration is fixed at creation. A route that needs different limits
 creates its own limiter with its own `overrides`.
+
+```ts
+const reportRateLimiter = createLocalRateLimiter({
+  client: redis,
+  logger,
+  overrides: {
+    points: 5,
+    duration: 60,
+    fallback: { points: 5, duration: 60 },
+    prefix: 'reports',
+  },
+})
+```
+
+Fallback is independent of the primary window. Omit `fallback` to use the
+factory default: 10 points per second for the base and global limiters, or 5
+points per second for the local limiter. An override must provide both
+`points` and `duration`.
 
 Store keys live under `rate-limit:<prefix>:` (steady) and
 `rate-limit-burst:<prefix>:` (burst).

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -99,13 +99,13 @@ and `toHttpHeaders` instead.
 
 Every limiter accepts `overrides` of shape:
 
-| Field      | Default                                         | Meaning                                                                           |
-| ---------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| `points`   | `50`                                            | Consumption points per steady window                                              |
-| `duration` | `10`                                            | Steady window in seconds                                                          |
-| `burst`    | `{ points: 20, duration: 30 }`                  | Extra short-lived allowance; omit to inherit, `null` to disable                   |
-| `fallback` | `{ points: 10, duration: 1 }` (`5/1` for local) | Independent in-memory allowance, with burst granting nothing extra while degraded |
-| `prefix`   | `'api'` / `'global'` / `'local'`                | Namespace segment isolating this limiter's counters in the shared store           |
+| Field      | Default                                          | Meaning                                                                           |
+| ---------- | ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `points`   | `50`                                             | Consumption points per steady window                                              |
+| `duration` | `10`                                             | Steady window in seconds                                                          |
+| `burst`    | `{ points: 20, duration: 30 }`                   | Extra short-lived allowance; omit to inherit, `null` to disable                   |
+| `fallback` | `{ points: 5, duration: 1 }` (`10/1` for global) | Independent in-memory allowance, with burst granting nothing extra while degraded |
+| `prefix`   | `'api'` / `'global'` / `'local'`                 | Namespace segment isolating this limiter's counters in the shared store           |
 
 Configuration is fixed at creation. A route that needs different limits
 creates its own limiter with its own `overrides`.
@@ -119,14 +119,13 @@ const reportRateLimiter = createLocalRateLimiter({
     duration: 60,
     burst: { points: 10, duration: 15 },
     fallback: { points: 5, duration: 60 },
-    prefix: 'reports',
   },
 })
 ```
 
 Fallback is independent of the primary window. Omit `fallback` to use the
-factory default: 10 points per second for the base and global limiters, or 5
-points per second for the local limiter. An override must provide both
+factory default: 5 points per second for the base and local limiters, or 10
+points per second for the global limiter. An override must provide both
 `points` and `duration`.
 
 Store keys live under `rate-limit:<prefix>:` (steady) and

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -43,24 +43,8 @@ export const globalRateLimiter = createGlobalRateLimiter({ client: redis, logger
 export const localRateLimiter = createLocalRateLimiter({ client: redis, logger })
 ```
 
-The global limiter validates and normalizes IP addresses by default. If the
-application already supplies a trusted, canonical key, pass
-`skipKeyNormalization: true` to use the string verbatim. This also disables
-IPv6 /64 bucketing and IPv4-mapped normalization, so do not use it with
-attacker-controlled or unnormalized values.
-
-The factory `logger`'s `error` fires when no Redis client is configured, since
-enforcement is then degraded (per-instance, not shared across replicas), not
-just misconfigured. `warn` fires whenever a rate-limit value is clamped to a
-safe integer (out of range, or a fractional value truncated toward zero),
-reporting the field's original and clamped values. Both fire once when the
-limiter is created, so a base/system logger fits. A Redis error that escapes
-the in-memory insurance limiter is a separate, per-request `error` (see
-[Checking limits](#checking-limits)).
-
-Without a `client`, limits are enforced in memory — functional, but
-per-instance and not shared across replicas. The factory `logger`'s `error`
-surfaces that trade-off.
+When `client` is omitted, the limiter runs on in-memory counters. This is suitable for tests and local development. However, as limits are
+per-instance and not shared across replicas, this is not suitable for a production use case.
 
 ## Checking limits
 
@@ -75,7 +59,7 @@ await localRateLimiter.check({
   // the raw URL: raw URLs give every parameter value its own bucket.
   resource: 'bookings.create',
   // Optional request-scoped logger: request diagnostics (an unexpected store
-  // error, reported to `error`) then carry this request's identity.
+  // error) then carry this request's identity.
   logger: req.log,
 })
 ```
@@ -115,13 +99,13 @@ and `toHttpHeaders` instead.
 
 Every limiter accepts `overrides` of shape:
 
-| Field      | Default                                         | Meaning                                                                    |
-| ---------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
-| `points`   | `50`                                            | Consumption points per steady window                                       |
-| `duration` | `10`                                            | Steady window in seconds                                                   |
-| `burst`    | `{ points: 20, duration: 30 }`                  | Extra short-lived allowance; omit to inherit, `null` to disable            |
-| `fallback` | `{ points: 10, duration: 1 }` (`5/1` for local) | Independent in-memory allowance; burst grants nothing extra while degraded |
-| `prefix`   | `'api'` / `'global'` / `'local'`                | Namespace segment isolating this limiter's counters in the shared store    |
+| Field      | Default                                         | Meaning                                                                           |
+| ---------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| `points`   | `50`                                            | Consumption points per steady window                                              |
+| `duration` | `10`                                            | Steady window in seconds                                                          |
+| `burst`    | `{ points: 20, duration: 30 }`                  | Extra short-lived allowance; omit to inherit, `null` to disable                   |
+| `fallback` | `{ points: 10, duration: 1 }` (`5/1` for local) | Independent in-memory allowance, with burst granting nothing extra while degraded |
+| `prefix`   | `'api'` / `'global'` / `'local'`                | Namespace segment isolating this limiter's counters in the shared store           |
 
 Configuration is fixed at creation. A route that needs different limits
 creates its own limiter with its own `overrides`.
@@ -133,6 +117,7 @@ const reportRateLimiter = createLocalRateLimiter({
   overrides: {
     points: 5,
     duration: 60,
+    burst: { points: 10, duration: 15 },
     fallback: { points: 5, duration: 60 },
     prefix: 'reports',
   },

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -50,11 +50,14 @@
     "@microsoft/api-extractor": "^7.58.9",
     "@opengovsg/eslint-config-starter-kitty": "workspace:*",
     "@opengovsg/prettier-config-starter-kitty": "workspace:*",
+    "@opengovsg/testcontainers": "workspace:*",
     "@swc/core": "^1.6.13",
     "@types/node": "^20",
     "ioredis": "^5.8.2",
+    "testcontainers": "^12.0.4",
     "typescript": "^5.4.5",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "prettier": "@opengovsg/prettier-config-starter-kitty"
 }

--- a/packages/rate-limit/src/__tests__/limiters.test.ts
+++ b/packages/rate-limit/src/__tests__/limiters.test.ts
@@ -7,8 +7,8 @@ import { createGlobalRateLimiter, createLocalRateLimiter, type Logger, RateLimit
 
 const uniquePrefix = () => `test-${randomUUID()}`
 
-// A Logger stub whose `warn` and `error` methods are vitest mocks, for
-// asserting which log reached which logger.
+// A Logger stub whose `warn`/`error` methods are vitest mocks, for asserting
+// which diagnostics reached which logger.
 const createLoggerStub = () => {
   const warn = vi.fn<Logger['warn']>()
   const error = vi.fn<Logger['error']>()

--- a/packages/rate-limit/src/__tests__/limiters.test.ts
+++ b/packages/rate-limit/src/__tests__/limiters.test.ts
@@ -21,8 +21,12 @@ describe('createGlobalRateLimiter', () => {
   it('keys purely by IP, isolating distinct clients', async () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: '1.2.3.4' })
@@ -35,8 +39,12 @@ describe('createGlobalRateLimiter', () => {
   it('buckets IPv6 addresses by /64 prefix', async () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: '2001:db8:85a3:1::1' })
@@ -51,8 +59,12 @@ describe('createGlobalRateLimiter', () => {
   it('normalizes equivalent IPv6 spellings into one bucket', async () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: '2001:db8::1' })
@@ -63,8 +75,12 @@ describe('createGlobalRateLimiter', () => {
   it('keys a compressed spelling whose tail reaches into the /64 prefix identically to its expanded form', async () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     // `::` here compresses a single zero group inside the first four groups,
@@ -76,8 +92,12 @@ describe('createGlobalRateLimiter', () => {
   it('ignores IPv6 zone IDs, which never occupy the /64 prefix', async () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: 'fe80::1%eth0' })
@@ -87,8 +107,12 @@ describe('createGlobalRateLimiter', () => {
   it('normalizes IPv4-mapped IPv6 spellings to their embedded IPv4 address', async () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 2, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 2, duration: 10 },
+      overrides: {
+        points: 2,
+        duration: 10,
+        fallback: { points: 2, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: '1.2.3.4' })
@@ -100,8 +124,12 @@ describe('createGlobalRateLimiter', () => {
     const requestLogger = createLoggerStub()
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: 'not-an-ip', logger: requestLogger })
@@ -178,8 +206,12 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       skipKeyNormalization: true,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: 'not-an-ip', logger: requestLogger })
@@ -192,8 +224,12 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       skipKeyNormalization: true,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      fallback: { points: 1, duration: 10 },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: '2001:db8::1' })
@@ -236,9 +272,9 @@ describe('createLocalRateLimiter', () => {
         points: 1,
         duration: 10,
         burst: null,
+        fallback: { points: 1, duration: 10 },
         prefix: uniquePrefix(),
       },
-      fallback: { points: 1, duration: 10 },
     })
     const actor = randomUUID()
 
@@ -256,9 +292,9 @@ describe('createLocalRateLimiter', () => {
         points: 1,
         duration: 10,
         burst: null,
+        fallback: { points: 1, duration: 10 },
         prefix: uniquePrefix(),
       },
-      fallback: { points: 1, duration: 10 },
     })
     const resource = 'auth.login'
 

--- a/packages/rate-limit/src/__tests__/limiters.test.ts
+++ b/packages/rate-limit/src/__tests__/limiters.test.ts
@@ -22,6 +22,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: '1.2.3.4' })
@@ -35,6 +36,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: '2001:db8:85a3:1::1' })
@@ -50,6 +52,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: '2001:db8::1' })
@@ -61,6 +64,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     // `::` here compresses a single zero group inside the first four groups,
@@ -73,6 +77,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: 'fe80::1%eth0' })
@@ -83,6 +88,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 2, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 2, duration: 10 },
     })
 
     await limiter.check({ ip: '1.2.3.4' })
@@ -95,6 +101,7 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: 'not-an-ip', logger: requestLogger })
@@ -172,6 +179,7 @@ describe('createGlobalRateLimiter', () => {
       logger: defaultLogger,
       skipKeyNormalization: true,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: 'not-an-ip', logger: requestLogger })
@@ -185,6 +193,7 @@ describe('createGlobalRateLimiter', () => {
       logger: defaultLogger,
       skipKeyNormalization: true,
       overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      fallback: { points: 1, duration: 10 },
     })
 
     await limiter.check({ ip: '2001:db8::1' })
@@ -193,21 +202,10 @@ describe('createGlobalRateLimiter', () => {
     })
   })
 
-  it('defaults to 100 points per second with no burst', async () => {
-    const limiter = createGlobalRateLimiter({
-      logger: defaultLogger,
-      overrides: { prefix: uniquePrefix() },
-    })
-    const ip = `10.0.0.${Math.floor(Math.random() * 255)}`
-
-    const first = await limiter.check({ ip })
-    expect(first.points.remaining).toBe(99)
-
-    for (let i = 0; i < 99; i++) {
-      await limiter.check({ ip })
-    }
-    await expect(limiter.check({ ip })).rejects.toBeInstanceOf(RateLimitExceededError)
-  })
+  // The global limiter's literal built-in default (100 points/second, no
+  // burst) can no longer be observed via the no-client path — the fallback
+  // allowance (10/s) governs it instead, per ADR 0010. See
+  // `rate-limiter.docker.test.ts` for that coverage against a real Redis.
 
   it('forwards a per-check logger through to the underlying limiter', async () => {
     const requestLogger = createLoggerStub()
@@ -245,6 +243,7 @@ describe('createLocalRateLimiter', () => {
         burst: null,
         prefix: uniquePrefix(),
       },
+      fallback: { points: 1, duration: 10 },
     })
     const actor = randomUUID()
 
@@ -264,6 +263,7 @@ describe('createLocalRateLimiter', () => {
         burst: null,
         prefix: uniquePrefix(),
       },
+      fallback: { points: 1, duration: 10 },
     })
     const resource = 'auth.login'
 

--- a/packages/rate-limit/src/__tests__/limiters.test.ts
+++ b/packages/rate-limit/src/__tests__/limiters.test.ts
@@ -202,11 +202,6 @@ describe('createGlobalRateLimiter', () => {
     })
   })
 
-  // The global limiter's literal built-in default (100 points/second, no
-  // burst) can no longer be observed via the no-client path — the fallback
-  // allowance (10/s) governs it instead, per ADR 0010. See
-  // `rate-limiter.docker.test.ts` for that coverage against a real Redis.
-
   it('forwards a per-check logger through to the underlying limiter', async () => {
     const requestLogger = createLoggerStub()
     const storeError = new Error('boom')

--- a/packages/rate-limit/src/__tests__/limiters.test.ts
+++ b/packages/rate-limit/src/__tests__/limiters.test.ts
@@ -148,7 +148,12 @@ describe('createGlobalRateLimiter', () => {
     const requestLogger = createLoggerStub()
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: invalidIp, logger: requestLogger })
@@ -169,7 +174,12 @@ describe('createGlobalRateLimiter', () => {
       const requestLogger = createLoggerStub()
       const limiter = createGlobalRateLimiter({
         logger: defaultLogger,
-        overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+        overrides: {
+          points: 1,
+          duration: 10,
+          fallback: { points: 1, duration: 10 },
+          prefix: uniquePrefix(),
+        },
       })
 
       // @ts-expect-error simulates a JavaScript caller with no type checking.
@@ -189,7 +199,12 @@ describe('createGlobalRateLimiter', () => {
     const limiter = createGlobalRateLimiter({
       logger: defaultLogger,
       skipKeyNormalization: true,
-      overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
+      overrides: {
+        points: 1,
+        duration: 10,
+        fallback: { points: 1, duration: 10 },
+        prefix: uniquePrefix(),
+      },
     })
 
     await limiter.check({ ip: undefined, logger: requestLogger })

--- a/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
@@ -47,10 +47,10 @@ describe('rate limiters against a real, healthy Redis', () => {
     const ip = `10.0.0.${Math.floor(Math.random() * 255)}`
 
     const first = await limiter.check({ ip })
-    expect(first.remainingPoints).toBe(99)
+    expect(first.points.remaining).toBe(99)
 
     const rest = await limiter.check({ ip, points: 99 })
-    expect(rest.remainingPoints).toBe(0)
+    expect(rest.points.remaining).toBe(0)
     await expect(limiter.check({ ip })).rejects.toBeInstanceOf(RateLimitExceededError)
   })
 

--- a/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
@@ -54,31 +54,27 @@ describe('rate limiters against a real, healthy Redis', () => {
     await expect(limiter.check({ ip })).rejects.toBeInstanceOf(RateLimitExceededError)
   })
 
-  it('honors a per-check options override on the local limiter when Redis is healthy', async () => {
+  it("enforces the local limiter's creation-time defaults when Redis is healthy", async () => {
     const limiter = createLocalRateLimiter({
       client,
-      defaults: { prefix: uniquePrefix() },
+      defaults: { points: 1, duration: 10, burst: null, prefix: uniquePrefix() },
     })
     const actor = randomUUID()
-    const options = { points: 1, duration: 10, burst: null }
 
-    await limiter.check({ actor, resource: 'auth.otp', options })
-    await expect(limiter.check({ actor, resource: 'auth.otp', options })).rejects.toBeInstanceOf(RateLimitExceededError)
+    await limiter.check({ actor, resource: 'auth.otp' })
+    await expect(limiter.check({ actor, resource: 'auth.otp' })).rejects.toBeInstanceOf(RateLimitExceededError)
   })
 
   it('grants extra requests from the burst allowance when Redis is healthy', async () => {
     const limiter = createLocalRateLimiter({
       client,
-      defaults: { prefix: uniquePrefix() },
+      defaults: { points: 1, duration: 10, burst: { points: 2, duration: 30 }, prefix: uniquePrefix() },
     })
     const actor = randomUUID()
-    const options = { points: 1, duration: 10, burst: { points: 2, duration: 30 } }
 
-    await limiter.check({ actor, resource: 'bookings.create', options })
-    await limiter.check({ actor, resource: 'bookings.create', options })
-    await limiter.check({ actor, resource: 'bookings.create', options })
-    await expect(limiter.check({ actor, resource: 'bookings.create', options })).rejects.toBeInstanceOf(
-      RateLimitExceededError,
-    )
+    await limiter.check({ actor, resource: 'bookings.create' })
+    await limiter.check({ actor, resource: 'bookings.create' })
+    await limiter.check({ actor, resource: 'bookings.create' })
+    await expect(limiter.check({ actor, resource: 'bookings.create' })).rejects.toBeInstanceOf(RateLimitExceededError)
   })
 })

--- a/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
@@ -3,12 +3,20 @@ import { randomUUID } from 'node:crypto'
 import { getMappedPort, redis } from '@opengovsg/testcontainers'
 import { createGlobalSetup, type ProvidedContainers } from '@opengovsg/testcontainers/vitest'
 import { Redis } from 'ioredis'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { TestProject } from 'vitest/node'
 
-import { createGlobalRateLimiter, createLocalRateLimiter, RateLimitExceededError } from '../index.js'
+import { createGlobalRateLimiter, createLocalRateLimiter, type Logger, RateLimitExceededError } from '../index.js'
 
 const uniquePrefix = () => `test-${randomUUID()}`
+
+const createLoggerStub = () => {
+  const warn = vi.fn<Logger['warn']>()
+  const error = vi.fn<Logger['error']>()
+  return { warn, error } satisfies Logger
+}
+
+const defaultLogger = createLoggerStub()
 
 // Real Docker required: boots a single Redis container for this file via the
 // testcontainers globalSetup factory, torn down after all tests run. Exists
@@ -42,14 +50,18 @@ describe('rate limiters against a real, healthy Redis', () => {
   it("enforces the global limiter's built-in default of 100 points per second when Redis is healthy", async () => {
     const limiter = createGlobalRateLimiter({
       client,
-      defaults: { prefix: uniquePrefix() },
+      logger: defaultLogger,
+      overrides: { prefix: uniquePrefix() },
     })
     const ip = `10.0.0.${Math.floor(Math.random() * 255)}`
 
     const first = await limiter.check({ ip })
     expect(first.points.remaining).toBe(99)
 
-    const rest = await limiter.check({ ip, points: 99 })
+    let rest = first
+    for (let i = 0; i < 99; i++) {
+      rest = await limiter.check({ ip })
+    }
     expect(rest.points.remaining).toBe(0)
     await expect(limiter.check({ ip })).rejects.toBeInstanceOf(RateLimitExceededError)
   })
@@ -57,7 +69,8 @@ describe('rate limiters against a real, healthy Redis', () => {
   it("enforces the local limiter's creation-time defaults when Redis is healthy", async () => {
     const limiter = createLocalRateLimiter({
       client,
-      defaults: {
+      logger: defaultLogger,
+      overrides: {
         points: 1,
         duration: 10,
         burst: null,
@@ -73,7 +86,8 @@ describe('rate limiters against a real, healthy Redis', () => {
   it('grants extra requests from the burst allowance when Redis is healthy', async () => {
     const limiter = createLocalRateLimiter({
       client,
-      defaults: {
+      logger: defaultLogger,
+      overrides: {
         points: 1,
         duration: 10,
         burst: { points: 2, duration: 30 },

--- a/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
@@ -57,7 +57,12 @@ describe('rate limiters against a real, healthy Redis', () => {
   it("enforces the local limiter's creation-time defaults when Redis is healthy", async () => {
     const limiter = createLocalRateLimiter({
       client,
-      defaults: { points: 1, duration: 10, burst: null, prefix: uniquePrefix() },
+      defaults: {
+        points: 1,
+        duration: 10,
+        burst: null,
+        prefix: uniquePrefix(),
+      },
     })
     const actor = randomUUID()
 
@@ -68,7 +73,12 @@ describe('rate limiters against a real, healthy Redis', () => {
   it('grants extra requests from the burst allowance when Redis is healthy', async () => {
     const limiter = createLocalRateLimiter({
       client,
-      defaults: { points: 1, duration: 10, burst: { points: 2, duration: 30 }, prefix: uniquePrefix() },
+      defaults: {
+        points: 1,
+        duration: 10,
+        burst: { points: 2, duration: 30 },
+        prefix: uniquePrefix(),
+      },
     })
     const actor = randomUUID()
 

--- a/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.docker.test.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto'
+
+import { getMappedPort, redis } from '@opengovsg/testcontainers'
+import { createGlobalSetup, type ProvidedContainers } from '@opengovsg/testcontainers/vitest'
+import { Redis } from 'ioredis'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { TestProject } from 'vitest/node'
+
+import { createGlobalRateLimiter, createLocalRateLimiter, RateLimitExceededError } from '../index.js'
+
+const uniquePrefix = () => `test-${randomUUID()}`
+
+// Real Docker required: boots a single Redis container for this file via the
+// testcontainers globalSetup factory, torn down after all tests run. Exists
+// because the fallback allowance (ADR 0010) now governs the no-client and
+// Redis-not-ready paths, so verifying that a *healthy* Redis genuinely
+// enforces the primary points/duration configuration (not the fallback)
+// requires a real, reachable Redis — no stub can demonstrate this.
+describe('rate limiters against a real, healthy Redis', () => {
+  let client: Redis
+  let teardown: () => Promise<void>
+
+  beforeAll(async () => {
+    let provided: ProvidedContainers | undefined
+    const project = {
+      provide: (_key: string, value: ProvidedContainers) => {
+        provided = value
+      },
+    } as unknown as TestProject
+
+    teardown = await createGlobalSetup([redis()])(project)
+    const info = provided!.redis!
+    client = new Redis({ host: info.host, port: getMappedPort(info, 6379) })
+    await client.ping()
+  }, 180_000)
+
+  afterAll(async () => {
+    client.disconnect()
+    await teardown()
+  })
+
+  it("enforces the global limiter's built-in default of 100 points per second when Redis is healthy", async () => {
+    const limiter = createGlobalRateLimiter({
+      client,
+      defaults: { prefix: uniquePrefix() },
+    })
+    const ip = `10.0.0.${Math.floor(Math.random() * 255)}`
+
+    const first = await limiter.check({ ip })
+    expect(first.remainingPoints).toBe(99)
+
+    const rest = await limiter.check({ ip, points: 99 })
+    expect(rest.remainingPoints).toBe(0)
+    await expect(limiter.check({ ip })).rejects.toBeInstanceOf(RateLimitExceededError)
+  })
+
+  it('honors a per-check options override on the local limiter when Redis is healthy', async () => {
+    const limiter = createLocalRateLimiter({
+      client,
+      defaults: { prefix: uniquePrefix() },
+    })
+    const actor = randomUUID()
+    const options = { points: 1, duration: 10, burst: null }
+
+    await limiter.check({ actor, resource: 'auth.otp', options })
+    await expect(limiter.check({ actor, resource: 'auth.otp', options })).rejects.toBeInstanceOf(RateLimitExceededError)
+  })
+
+  it('grants extra requests from the burst allowance when Redis is healthy', async () => {
+    const limiter = createLocalRateLimiter({
+      client,
+      defaults: { prefix: uniquePrefix() },
+    })
+    const actor = randomUUID()
+    const options = { points: 1, duration: 10, burst: { points: 2, duration: 30 } }
+
+    await limiter.check({ actor, resource: 'bookings.create', options })
+    await limiter.check({ actor, resource: 'bookings.create', options })
+    await limiter.check({ actor, resource: 'bookings.create', options })
+    await expect(limiter.check({ actor, resource: 'bookings.create', options })).rejects.toBeInstanceOf(
+      RateLimitExceededError,
+    )
+  })
+})

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -7,8 +7,8 @@ import { createRateLimiter, type Logger, RateLimitExceededError, type RedisClien
 
 const uniquePrefix = () => `test-${randomUUID()}`
 
-// A Logger stub whose `warn` and `error` methods are vitest mocks, for
-// asserting which log reached which logger.
+// A Logger stub whose `warn`/`error` methods are vitest mocks, for asserting
+// which diagnostics reached which logger.
 const createLoggerStub = () => {
   const warn = vi.fn<Logger['warn']>()
   const error = vi.fn<Logger['error']>()
@@ -85,7 +85,7 @@ describe('createRateLimiter', () => {
       await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
     })
 
-    it('warns that limits are per-instance when no client is configured', async () => {
+    it('reports to error that limits are per-instance when no client is configured', async () => {
       const logger = createLoggerStub()
       const limiter = createRateLimiter({
         logger,
@@ -99,7 +99,7 @@ describe('createRateLimiter', () => {
 
       await limiter.check({ key: randomUUID() })
 
-      expect(logger.warn.mock.calls.some(([input]) => input.message.includes('in-memory'))).toBe(true)
+      expect(logger.error.mock.calls.some(([input]) => input.message.includes('in-memory'))).toBe(true)
     })
 
     it('clamps invalid configuration values', async () => {
@@ -176,7 +176,8 @@ describe('createRateLimiter', () => {
       const logger = createLoggerStub()
       const storeError = new Error('boom')
       // A non-RateLimiterRes rejection is neither a limit nor absorbed by the
-      // insurance limiter, so it reaches the error path and is rethrown.
+      // insurance limiter, so it reaches the error-reporting path and is
+      // rethrown.
       const spy = vi.spyOn(RateLimiterMemory.prototype, 'consume').mockRejectedValue(storeError)
       try {
         const limiter = createRateLimiter({
@@ -197,7 +198,7 @@ describe('createRateLimiter', () => {
       }
     })
 
-    it('routes a per-check logger the request warnings, overriding the factory logger', async () => {
+    it('routes a per-check logger the request diagnostics, overriding the factory logger', async () => {
       const factoryLogger = createLoggerStub()
       const requestLogger = createLoggerStub()
       const storeError = new Error('boom')
@@ -223,7 +224,7 @@ describe('createRateLimiter', () => {
       }
     })
 
-    it('routes configuration warnings to the factory logger even when a per-check logger is given', async () => {
+    it('routes configuration diagnostics to the factory logger even when a per-check logger is given', async () => {
       const factoryLogger = createLoggerStub()
       const requestLogger = createLoggerStub()
       const limiter = createRateLimiter({
@@ -239,8 +240,8 @@ describe('createRateLimiter', () => {
       await limiter.check({ key: randomUUID(), logger: requestLogger })
 
       const inMemory = (input: { message: string }) => input.message.includes('in-memory')
-      expect(factoryLogger.warn.mock.calls.some(([input]) => inMemory(input))).toBe(true)
-      expect(requestLogger.warn.mock.calls.some(([input]) => inMemory(input))).toBe(false)
+      expect(factoryLogger.error.mock.calls.some(([input]) => inMemory(input))).toBe(true)
+      expect(requestLogger.error.mock.calls.some(([input]) => inMemory(input))).toBe(false)
     })
 
     describe('clamp warnings', () => {

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -26,9 +26,9 @@ describe('createRateLimiter', () => {
           points: 5,
           duration: 10,
           burst: null,
+          fallback: { points: 5, duration: 10 },
           prefix: uniquePrefix(),
         },
-        fallback: { points: 5, duration: 10 },
       })
 
       const info = await limiter.check({ key: randomUUID() })
@@ -48,9 +48,9 @@ describe('createRateLimiter', () => {
           points: 2,
           duration: 10,
           burst: null,
+          fallback: { points: 2, duration: 10 },
           prefix: uniquePrefix(),
         },
-        fallback: { points: 2, duration: 10 },
       })
       const key = randomUUID()
 
@@ -72,9 +72,9 @@ describe('createRateLimiter', () => {
           points: 1,
           duration: 10,
           burst: { points: 5, duration: 30 },
+          fallback: { points: 1, duration: 10 },
           prefix: uniquePrefix(),
         },
-        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 
@@ -109,9 +109,9 @@ describe('createRateLimiter', () => {
           points: 0,
           duration: 10,
           burst: null,
+          fallback: { points: 1, duration: 10 },
           prefix: uniquePrefix(),
         },
-        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 
@@ -124,19 +124,34 @@ describe('createRateLimiter', () => {
 
     it('enforces the default fallback allowance (10 points per second) regardless of a larger primary window', async () => {
       const limiter = createRateLimiter({
-        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
+        logger: defaultLogger,
+        overrides: {
+          points: 1000,
+          duration: 10,
+          burst: null,
+          prefix: uniquePrefix(),
+        },
       })
       const key = randomUUID()
 
-      const info = await limiter.check({ key, points: 10 })
+      for (let i = 0; i < 9; i++) {
+        await limiter.check({ key })
+      }
+      const info = await limiter.check({ key })
       expect(info.points.remaining).toBe(0)
       await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
     })
 
-    it('overrides the default fallback allowance via the fallback option', async () => {
+    it('overrides the default fallback allowance via overrides.fallback', async () => {
       const limiter = createRateLimiter({
-        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
-        fallback: { points: 2, duration: 30 },
+        logger: defaultLogger,
+        overrides: {
+          points: 1000,
+          duration: 10,
+          burst: null,
+          fallback: { points: 2, duration: 30 },
+          prefix: uniquePrefix(),
+        },
       })
       const key = randomUUID()
 
@@ -149,8 +164,13 @@ describe('createRateLimiter', () => {
       const logger = createLoggerStub()
       const limiter = createRateLimiter({
         logger,
-        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
-        fallback: { points: 0, duration: 10 },
+        overrides: {
+          points: 1000,
+          duration: 10,
+          burst: null,
+          fallback: { points: 0, duration: 10 },
+          prefix: uniquePrefix(),
+        },
       })
       const key = randomUUID()
 
@@ -164,8 +184,13 @@ describe('createRateLimiter', () => {
       const logger = createLoggerStub()
       createRateLimiter({
         logger,
-        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
-        fallback: { points: 5, duration: 0 },
+        overrides: {
+          points: 1000,
+          duration: 10,
+          burst: null,
+          fallback: { points: 5, duration: 0 },
+          prefix: uniquePrefix(),
+        },
       })
 
       const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback duration'))
@@ -252,9 +277,9 @@ describe('createRateLimiter', () => {
             points: 2.9,
             duration: 10.5,
             burst: { points: 1.9, duration: 30.9 },
+            fallback: { points: 2, duration: 10 },
             prefix: uniquePrefix(),
           },
-          fallback: { points: 2, duration: 10 },
         })
         const key = randomUUID()
 
@@ -365,9 +390,9 @@ describe('createRateLimiter', () => {
           points: 1,
           duration: 10,
           burst: null,
+          fallback: { points: 1, duration: 10 },
           prefix: uniquePrefix(),
         },
-        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 
@@ -380,14 +405,15 @@ describe('createRateLimiter', () => {
     it('grants nothing extra from burst when Redis is not ready, even though burst is configured', async () => {
       const client = { status: 'end' } as unknown as RedisClient
       const limiter = createRateLimiter({
+        logger: defaultLogger,
         client,
-        defaults: {
+        overrides: {
           points: 1,
           duration: 10,
           burst: { points: 5, duration: 30 },
+          fallback: { points: 1, duration: 10 },
           prefix: uniquePrefix(),
         },
-        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -271,24 +271,34 @@ describe('createRateLimiter', () => {
 
     describe('clamp warnings', () => {
       it('truncates non-integer points and duration configuration values toward zero', async () => {
+        const logger = createLoggerStub()
         const limiter = createRateLimiter({
-          logger: defaultLogger,
+          logger,
           overrides: {
             points: 2.9,
             duration: 10.5,
             burst: { points: 1.9, duration: 30.9 },
-            fallback: { points: 2, duration: 10 },
+            fallback: { points: 2.9, duration: 10.5 },
             prefix: uniquePrefix(),
           },
         })
         const key = randomUUID()
 
-        // The primary points truncate to 2, but burst never applies while
-        // running off memory (ADR 0010), so only 2 checks succeed before the
-        // 3rd is rejected.
+        // With no Redis client, the truncated fallback allowance (2.9 to 2)
+        // is enforced and burst capacity is unavailable (ADR 0010).
         await limiter.check({ key })
         await limiter.check({ key })
         await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
+
+        const clampedValues = logger.warn.mock.calls.map(([input]) => [input.message, input.context?.clamped])
+        expect(clampedValues).toEqual([
+          ['Rate limit points was clamped', 2],
+          ['Rate limit duration was clamped', 10],
+          ['Rate limit fallback points was clamped', 2],
+          ['Rate limit fallback duration was clamped', 10],
+          ['Rate limit burst points was clamped', 1],
+          ['Rate limit burst duration was clamped', 30],
+        ])
       })
 
       it('warns about a clamped configuration once at creation, not on every check', async () => {

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -156,8 +156,8 @@ describe('createRateLimiter', () => {
 
       await limiter.check({ key })
       await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
-      const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback.points'))
-      expect(clampCall?.[0].context?.requested).toBe(0)
+      const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback points'))
+      expect(clampCall?.[0].context?.value).toBe(0)
     })
 
     it('clamps a non-positive fallback.duration to 1 and warns', () => {
@@ -168,8 +168,8 @@ describe('createRateLimiter', () => {
         fallback: { points: 5, duration: 0 },
       })
 
-      const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback.duration'))
-      expect(clampCall?.[0].context?.requested).toBe(0)
+      const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback duration'))
+      expect(clampCall?.[0].context?.value).toBe(0)
     })
 
     it('reports an unexpected limiter error to the logger with a top-level error and rethrows it', async () => {

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -28,6 +28,7 @@ describe('createRateLimiter', () => {
           burst: null,
           prefix: uniquePrefix(),
         },
+        fallback: { points: 5, duration: 10 },
       })
 
       const info = await limiter.check({ key: randomUUID() })
@@ -49,6 +50,7 @@ describe('createRateLimiter', () => {
           burst: null,
           prefix: uniquePrefix(),
         },
+        fallback: { points: 2, duration: 10 },
       })
       const key = randomUUID()
 
@@ -63,49 +65,24 @@ describe('createRateLimiter', () => {
       expect(rateLimitError.message).toMatch(/Rate limit exceeded/)
     })
 
-    it('grants extra requests from the burst allowance after the steady window is exhausted', async () => {
+    it('never grants extra requests from burst while running off memory, even when burst is configured', async () => {
       const limiter = createRateLimiter({
         logger: defaultLogger,
         overrides: {
           points: 1,
           duration: 10,
-          burst: { points: 2, duration: 30 },
+          burst: { points: 5, duration: 30 },
           prefix: uniquePrefix(),
         },
+        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 
       await limiter.check({ key })
-      await limiter.check({ key })
-      await limiter.check({ key })
+      // Burst never engages while enforcement runs off memory (ADR 0010): the
+      // fallback allowance above is the only capacity available, regardless of
+      // the primary burst configuration.
       await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
-    })
-
-    it('inherits the built-in burst when overrides omit it and disables it when null', async () => {
-      // Burst omitted: the built-in { points: 20, duration: 30 } applies, so
-      // 1 steady + 20 burst checks pass before the 22nd is rejected.
-      const inheriting = createRateLimiter({
-        logger: defaultLogger,
-        overrides: { points: 1, duration: 10, prefix: uniquePrefix() },
-      })
-      const inheritingKey = randomUUID()
-      for (let i = 0; i < 21; i++) {
-        await inheriting.check({ key: inheritingKey })
-      }
-      await expect(inheriting.check({ key: inheritingKey })).rejects.toBeInstanceOf(RateLimitExceededError)
-
-      const burstless = createRateLimiter({
-        logger: defaultLogger,
-        overrides: {
-          points: 1,
-          duration: 10,
-          burst: null,
-          prefix: uniquePrefix(),
-        },
-      })
-      const burstlessKey = randomUUID()
-      await burstless.check({ key: burstlessKey })
-      await expect(burstless.check({ key: burstlessKey })).rejects.toBeInstanceOf(RateLimitExceededError)
     })
 
     it('warns that limits are per-instance when no client is configured', async () => {
@@ -134,12 +111,65 @@ describe('createRateLimiter', () => {
           burst: null,
           prefix: uniquePrefix(),
         },
+        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 
-      // points clamped to 1: the first check consumes it, the second is rejected.
+      // Primary points clamped to 1 (still warned below, even though the
+      // fallback above — not this clamped primary value — is what's actually
+      // enforced in the no-client path per ADR 0010).
       await limiter.check({ key })
       await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
+    })
+
+    it('enforces the default fallback allowance (10 points per second) regardless of a larger primary window', async () => {
+      const limiter = createRateLimiter({
+        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
+      })
+      const key = randomUUID()
+
+      const info = await limiter.check({ key, points: 10 })
+      expect(info.points.remaining).toBe(0)
+      await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
+    })
+
+    it('overrides the default fallback allowance via the fallback option', async () => {
+      const limiter = createRateLimiter({
+        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
+        fallback: { points: 2, duration: 30 },
+      })
+      const key = randomUUID()
+
+      await limiter.check({ key })
+      await limiter.check({ key })
+      await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
+    })
+
+    it('clamps a non-positive fallback.points to 1 and warns', async () => {
+      const logger = createLoggerStub()
+      const limiter = createRateLimiter({
+        logger,
+        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
+        fallback: { points: 0, duration: 10 },
+      })
+      const key = randomUUID()
+
+      await limiter.check({ key })
+      await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
+      const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback.points'))
+      expect(clampCall?.[0].context?.requested).toBe(0)
+    })
+
+    it('clamps a non-positive fallback.duration to 1 and warns', () => {
+      const logger = createLoggerStub()
+      createRateLimiter({
+        logger,
+        defaults: { points: 1000, duration: 10, burst: null, prefix: uniquePrefix() },
+        fallback: { points: 5, duration: 0 },
+      })
+
+      const clampCall = logger.warn.mock.calls.find(([input]) => input.message.includes('fallback.duration'))
+      expect(clampCall?.[0].context?.requested).toBe(0)
     })
 
     it('reports an unexpected limiter error to the logger with a top-level error and rethrows it', async () => {
@@ -335,6 +365,27 @@ describe('createRateLimiter', () => {
           burst: null,
           prefix: uniquePrefix(),
         },
+        fallback: { points: 1, duration: 10 },
+      })
+      const key = randomUUID()
+
+      await expect(limiter.check({ key })).resolves.toMatchObject({
+        points: { remaining: 0 },
+      })
+      await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
+    })
+
+    it('grants nothing extra from burst when Redis is not ready, even though burst is configured', async () => {
+      const client = { status: 'end' } as unknown as RedisClient
+      const limiter = createRateLimiter({
+        client,
+        defaults: {
+          points: 1,
+          duration: 10,
+          burst: { points: 5, duration: 30 },
+          prefix: uniquePrefix(),
+        },
+        fallback: { points: 1, duration: 10 },
       })
       const key = randomUUID()
 

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -122,7 +122,7 @@ describe('createRateLimiter', () => {
       await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)
     })
 
-    it('enforces the default fallback allowance (10 points per second) regardless of a larger primary window', async () => {
+    it('enforces the default fallback allowance (5 points per second) regardless of a larger primary window', async () => {
       const limiter = createRateLimiter({
         logger: defaultLogger,
         overrides: {
@@ -134,7 +134,7 @@ describe('createRateLimiter', () => {
       })
       const key = randomUUID()
 
-      for (let i = 0; i < 9; i++) {
+      for (let i = 0; i < 4; i++) {
         await limiter.check({ key })
       }
       const info = await limiter.check({ key })

--- a/packages/rate-limit/src/__tests__/rate-limiter.test.ts
+++ b/packages/rate-limit/src/__tests__/rate-limiter.test.ts
@@ -244,7 +244,7 @@ describe('createRateLimiter', () => {
     })
 
     describe('clamp warnings', () => {
-      it('truncates non-integer points, duration, and burst configuration values toward zero', async () => {
+      it('truncates non-integer points and duration configuration values toward zero', async () => {
         const limiter = createRateLimiter({
           logger: defaultLogger,
           overrides: {
@@ -253,12 +253,13 @@ describe('createRateLimiter', () => {
             burst: { points: 1.9, duration: 30.9 },
             prefix: uniquePrefix(),
           },
+          fallback: { points: 2, duration: 10 },
         })
         const key = randomUUID()
 
-        // points truncates to 2, burst.points truncates to 1: 3 checks succeed
-        // (2 steady + 1 burst) before the 4th is rejected.
-        await limiter.check({ key })
+        // The primary points truncate to 2, but burst never applies while
+        // running off memory (ADR 0010), so only 2 checks succeed before the
+        // 3rd is rejected.
         await limiter.check({ key })
         await limiter.check({ key })
         await expect(limiter.check({ key })).rejects.toBeInstanceOf(RateLimitExceededError)

--- a/packages/rate-limit/src/constants.ts
+++ b/packages/rate-limit/src/constants.ts
@@ -27,6 +27,13 @@ export const LOCAL_RATE_LIMIT_DEFAULTS = {
 }
 
 /**
+ * The local limiter's fallback allowance (ADR 0010): tighter than the
+ * package-wide 10 points/second default, since 5 points/second already
+ * approximates this limiter's own steady default (50 points/10s).
+ */
+export const LOCAL_RATE_LIMIT_FALLBACK = { points: 5, duration: 1 }
+
+/**
  * Key for a shared bucket for requests whose client IP is unparseable.
  */
 export const UNKNOWN_BUCKET = 'unknown'

--- a/packages/rate-limit/src/constants.ts
+++ b/packages/rate-limit/src/constants.ts
@@ -7,6 +7,7 @@ export const BASE_RATE_LIMIT_DEFAULTS = {
   points: 50,
   duration: 10,
   burst: { points: 20, duration: 30 },
+  fallback: { points: 10, duration: 1 },
   prefix: 'api',
 }
 
@@ -18,20 +19,17 @@ export const GLOBAL_RATE_LIMIT_DEFAULTS = {
   points: 100,
   duration: 1,
   burst: null,
+  fallback: { points: 10, duration: 1 },
   prefix: 'global',
 }
 
 export const LOCAL_RATE_LIMIT_DEFAULTS = {
   ...BASE_RATE_LIMIT_DEFAULTS,
+  // Tighter than the package-wide 10 points/second fallback because 5
+  // points/second already approximates the local limiter's steady default.
+  fallback: { points: 5, duration: 1 },
   prefix: 'local',
 }
-
-/**
- * The local limiter's fallback allowance (ADR 0010): tighter than the
- * package-wide 10 points/second default, since 5 points/second already
- * approximates this limiter's own steady default (50 points/10s).
- */
-export const LOCAL_RATE_LIMIT_FALLBACK = { points: 5, duration: 1 }
 
 /**
  * Key for a shared bucket for requests whose client IP is unparseable.

--- a/packages/rate-limit/src/constants.ts
+++ b/packages/rate-limit/src/constants.ts
@@ -7,7 +7,7 @@ export const BASE_RATE_LIMIT_DEFAULTS = {
   points: 50,
   duration: 10,
   burst: { points: 20, duration: 30 },
-  fallback: { points: 10, duration: 1 },
+  fallback: { points: 5, duration: 1 },
   prefix: 'api',
 }
 
@@ -25,9 +25,6 @@ export const GLOBAL_RATE_LIMIT_DEFAULTS = {
 
 export const LOCAL_RATE_LIMIT_DEFAULTS = {
   ...BASE_RATE_LIMIT_DEFAULTS,
-  // Tighter than the package-wide 10 points/second fallback because 5
-  // points/second already approximates the local limiter's steady default.
-  fallback: { points: 5, duration: 1 },
   prefix: 'local',
 }
 

--- a/packages/rate-limit/src/global-rate-limiter.ts
+++ b/packages/rate-limit/src/global-rate-limiter.ts
@@ -16,13 +16,14 @@ export interface GlobalRateLimiter {
    * By default, IPv4 addresses are keyed per address and IPv6 addresses by
    * their /64 prefix, since a subscriber typically holds an entire /64 and
    * could otherwise mint a fresh bucket per request. IPv4-mapped IPv6
-   * addresses are keyed by the embedded IPv4 address. Pass
-   * `skipKeyNormalization: true` to use every string verbatim instead.
+   * addresses are keyed by the embedded IPv4 address.
    *
    * An unparseable IP falls into a shared `'unknown'` bucket rather than
    * being exempted, and logs an error so a broken extractor shows up in
    * logs, not just as 429s. `null`, `undefined`, and non-string values from
    * JavaScript callers are treated the same way.
+   *
+   * Pass `skipKeyNormalization: true` to use every string verbatim instead.
    *
    * Pass a request-scoped `logger` to attach request identity to anything
    * this call logs. Omit it to fall back to the factory logger.

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -8,7 +8,9 @@
  * be composed with a short burst allowance to absorb legitimate spikes.
  *
  * {@link createGlobalRateLimiter} guards pre-authentication traffic by client
- * IP. {@link createLocalRateLimiter} enforces per-actor, per-resource quotas
+ * IP.
+ *
+ * {@link createLocalRateLimiter} enforces per-actor, per-resource quotas
  * for identified traffic.
  *
  * {@link createRateLimiter} exposes the underlying core for anything else.

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -26,6 +26,7 @@ export { createRateLimiter } from './rate-limiter.js'
 export type {
   BurstConfig,
   CreateRateLimiterOptions,
+  FallbackConfig,
   Logger,
   RateLimitConfig,
   RateLimitInfo,

--- a/packages/rate-limit/src/local-rate-limiter.ts
+++ b/packages/rate-limit/src/local-rate-limiter.ts
@@ -1,4 +1,8 @@
-import { COLON_REPLACEMENT, LOCAL_RATE_LIMIT_DEFAULTS, VERTICAL_BAR } from './constants.js'
+import {
+  COLON_REPLACEMENT,
+  LOCAL_RATE_LIMIT_DEFAULTS,
+  VERTICAL_BAR,
+} from './constants.js'
 import { createRateLimiter } from './rate-limiter.js'
 import { CreateRateLimiterOptions, Logger, RateLimitInfo } from './types.js'
 import { mergeConfig } from './utilities.js'
@@ -28,7 +32,11 @@ export interface LocalRateLimiter {
    *
    * Throws {@link RateLimitExceededError} when the allowance is exhausted.
    */
-  check(args: { actor: string; resource: string; logger?: Logger }): Promise<RateLimitInfo>
+  check(args: {
+    actor: string
+    resource: string
+    logger?: Logger
+  }): Promise<RateLimitInfo>
 }
 
 /**
@@ -47,7 +55,9 @@ export type CreateLocalRateLimiterOptions = CreateRateLimiterOptions
  *
  * @public
  */
-export const createLocalRateLimiter = (options: CreateLocalRateLimiterOptions): LocalRateLimiter => {
+export const createLocalRateLimiter = (
+  options: CreateLocalRateLimiterOptions,
+): LocalRateLimiter => {
   const limiter = createRateLimiter({
     ...options,
     overrides: mergeConfig(LOCAL_RATE_LIMIT_DEFAULTS, options.overrides),
@@ -55,7 +65,9 @@ export const createLocalRateLimiter = (options: CreateLocalRateLimiterOptions): 
   return {
     check: ({ actor, resource, logger }) =>
       limiter.check({
-        key: `resource:${resource.replaceAll('|', VERTICAL_BAR).replaceAll(':', COLON_REPLACEMENT)}:actor:${actor}`,
+        key: `resource:${resource
+          .replaceAll('|', VERTICAL_BAR)
+          .replaceAll(':', COLON_REPLACEMENT)}:actor:${actor}`,
         logger,
       }),
   }

--- a/packages/rate-limit/src/local-rate-limiter.ts
+++ b/packages/rate-limit/src/local-rate-limiter.ts
@@ -1,8 +1,4 @@
-import {
-  COLON_REPLACEMENT,
-  LOCAL_RATE_LIMIT_DEFAULTS,
-  VERTICAL_BAR,
-} from './constants.js'
+import { COLON_REPLACEMENT, LOCAL_RATE_LIMIT_DEFAULTS, VERTICAL_BAR } from './constants.js'
 import { createRateLimiter } from './rate-limiter.js'
 import { CreateRateLimiterOptions, Logger, RateLimitInfo } from './types.js'
 import { mergeConfig } from './utilities.js'
@@ -32,11 +28,7 @@ export interface LocalRateLimiter {
    *
    * Throws {@link RateLimitExceededError} when the allowance is exhausted.
    */
-  check(args: {
-    actor: string
-    resource: string
-    logger?: Logger
-  }): Promise<RateLimitInfo>
+  check(args: { actor: string; resource: string; logger?: Logger }): Promise<RateLimitInfo>
 }
 
 /**
@@ -55,9 +47,7 @@ export type CreateLocalRateLimiterOptions = CreateRateLimiterOptions
  *
  * @public
  */
-export const createLocalRateLimiter = (
-  options: CreateLocalRateLimiterOptions,
-): LocalRateLimiter => {
+export const createLocalRateLimiter = (options: CreateLocalRateLimiterOptions): LocalRateLimiter => {
   const limiter = createRateLimiter({
     ...options,
     overrides: mergeConfig(LOCAL_RATE_LIMIT_DEFAULTS, options.overrides),
@@ -65,9 +55,7 @@ export const createLocalRateLimiter = (
   return {
     check: ({ actor, resource, logger }) =>
       limiter.check({
-        key: `resource:${resource
-          .replaceAll('|', VERTICAL_BAR)
-          .replaceAll(':', COLON_REPLACEMENT)}:actor:${actor}`,
+        key: `resource:${resource.replaceAll('|', VERTICAL_BAR).replaceAll(':', COLON_REPLACEMENT)}:actor:${actor}`,
         logger,
       }),
   }

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -56,6 +56,7 @@ const validateConfig = (config: RequiredRateLimitConfig, logger: Logger): Requir
       context: {
         value: config.fallback.points,
         clamped: validated.fallback.points,
+        prefix: config.prefix,
       },
     })
   }
@@ -65,6 +66,7 @@ const validateConfig = (config: RequiredRateLimitConfig, logger: Logger): Requir
       context: {
         value: config.fallback.duration,
         clamped: validated.fallback.duration,
+        prefix: config.prefix,
       },
     })
   }

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -3,28 +3,11 @@ import { BurstyRateLimiter, RateLimiterMemory, RateLimiterRedis } from 'rate-lim
 
 import { BASE_RATE_LIMIT_DEFAULTS } from './constants.js'
 import { RateLimitExceededError } from './errors.js'
-import type {
-  CreateRateLimiterOptions,
-  FallbackConfig,
-  Logger,
-  RateLimitInfo,
-  RedisClient,
-  RequiredRateLimitConfig,
-} from './types.js'
-import { clamp, mergeConfig, mergeFallback } from './utilities.js'
+import type { CreateRateLimiterOptions, Logger, RateLimitInfo, RedisClient, RequiredRateLimitConfig } from './types.js'
+import { clamp, mergeConfig } from './utilities.js'
 
 const STEADY_NAMESPACE = 'rate-limit:'
 const BURST_NAMESPACE = 'rate-limit-burst:'
-
-type RequiredFallbackConfig = Required<FallbackConfig>
-
-/**
- * The in-memory limiter's built-in fallback allowance: used as insurance
- * behind a Redis-backed window during an outage, and as the sole limiter when
- * no `client` is configured. A fixed, factory-independent constant rather
- * than derived from the primary configuration — see ADR 0010.
- */
-const BASE_FALLBACK: RequiredFallbackConfig = { points: 10, duration: 1 }
 
 /**
  * Clamp every numeric field, since caller input is not validated at the type
@@ -40,6 +23,10 @@ const validateConfig = (config: RequiredRateLimitConfig, logger: Logger): Requir
           duration: clamp(config.burst.duration),
         }
       : null,
+    fallback: {
+      points: clamp(config.fallback.points),
+      duration: clamp(config.fallback.duration),
+    },
     prefix: config.prefix,
   }
 
@@ -60,6 +47,24 @@ const validateConfig = (config: RequiredRateLimitConfig, logger: Logger): Requir
         value: config.duration,
         clamped: validated.duration,
         prefix: config.prefix,
+      },
+    })
+  }
+  if (validated.fallback.points !== config.fallback.points) {
+    logger.warn({
+      message: 'Rate limit fallback points was clamped',
+      context: {
+        value: config.fallback.points,
+        clamped: validated.fallback.points,
+      },
+    })
+  }
+  if (validated.fallback.duration !== config.fallback.duration) {
+    logger.warn({
+      message: 'Rate limit fallback duration was clamped',
+      context: {
+        value: config.fallback.duration,
+        clamped: validated.fallback.duration,
       },
     })
   }
@@ -133,16 +138,15 @@ export interface RateLimiter {
 
 const buildLimiter = (
   config: RequiredRateLimitConfig,
-  fallback: RequiredFallbackConfig,
   client: RedisClient | null,
   logger: Logger,
 ): RateLimiterAbstract | BurstyRateLimiter => {
-  const { points, duration, burst } = config
+  const { points, duration, burst, fallback } = config
   // The fallback allowance (ADR 0010) stands in for the primary window
   // whenever enforcement runs off memory, as insurance during a Redis outage
   // or as the sole limiter with no `client` configured, so it must never
   // reflect the (possibly much larger) primary points/duration.
-  const fallbackMemory = new RateLimiterMemory({
+  const memory = new RateLimiterMemory({
     points: fallback.points,
     duration: fallback.duration,
   })
@@ -157,7 +161,7 @@ const buildLimiter = (
         fallbackDuration: fallback.duration,
       },
     })
-    return fallbackMemory
+    return memory
   }
 
   const steady = new RateLimiterRedis({
@@ -166,7 +170,7 @@ const buildLimiter = (
     points,
     duration,
     keyPrefix: `${STEADY_NAMESPACE}${config.prefix}:`,
-    insuranceLimiter: fallbackMemory,
+    insuranceLimiter: memory,
   })
   if (!burst) {
     return steady
@@ -203,33 +207,7 @@ export const createRateLimiter = (options: CreateRateLimiterOptions): RateLimite
 
   const config = validateConfig(mergeConfig(BASE_RATE_LIMIT_DEFAULTS, options.overrides), logger)
 
-  // The fallback allowance is resolved once per factory. Keep it separate
-  // from the primary rate limit so an outage cannot grant the larger primary
-  // allowance.
-  const fallbackOptions = mergeFallback(BASE_FALLBACK, options.fallback)
-  const fallback: RequiredFallbackConfig = {
-    points: clamp(fallbackOptions.points),
-    duration: clamp(fallbackOptions.duration),
-  }
-  // A clamped fallback value is surfaced rather than silently corrected. The
-  // fallback governs the degraded path (ADR 0010), so a non-positive or
-  // non-finite value quietly becoming 1 would hide a misconfiguration in the
-  // path that matters most during an outage. Configuration warnings go to the
-  // factory logger, since the fallback is resolved once per factory.
-  if (fallback.points !== fallbackOptions.points) {
-    logger?.warn({
-      message: 'Rate limit fallback points was clamped',
-      context: { value: fallbackOptions.points, clamped: fallback.points },
-    })
-  }
-  if (fallback.duration !== fallbackOptions.duration) {
-    logger?.warn({
-      message: 'Rate limit fallback duration was clamped',
-      context: { value: fallbackOptions.duration, clamped: fallback.duration },
-    })
-  }
-
-  const limiter = buildLimiter(config, fallback, client, logger)
+  const limiter = buildLimiter(config, client, logger)
 
   return {
     check: async ({ key, logger: checkLogger }) => {

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -206,25 +206,26 @@ export const createRateLimiter = (options: CreateRateLimiterOptions): RateLimite
   // The fallback allowance is resolved once per factory. Keep it separate
   // from the primary rate limit so an outage cannot grant the larger primary
   // allowance.
-  const rawFallback = mergeFallback(BASE_FALLBACK, options.fallback)
+  const fallbackOptions = mergeFallback(BASE_FALLBACK, options.fallback)
   const fallback: RequiredFallbackConfig = {
-    points: clamp(rawFallback.points),
-    duration: clamp(rawFallback.duration),
+    points: clamp(fallbackOptions.points),
+    duration: clamp(fallbackOptions.duration),
   }
   // A clamped fallback value is surfaced rather than silently corrected. The
   // fallback governs the degraded path (ADR 0010), so a non-positive or
   // non-finite value quietly becoming 1 would hide a misconfiguration in the
-  // path that matters most during an outage.
-  if (fallback.points !== rawFallback.points) {
+  // path that matters most during an outage. Configuration warnings go to the
+  // factory logger, since the fallback is resolved once per factory.
+  if (fallback.points !== fallbackOptions.points) {
     logger?.warn({
       message: 'fallback.points was clamped to the minimum allowed value of 1',
-      context: { requested: rawFallback.points },
+      context: { requested: fallbackOptions.points },
     })
   }
-  if (fallback.duration !== rawFallback.duration) {
+  if (fallback.duration !== fallbackOptions.duration) {
     logger?.warn({
       message: 'fallback.duration was clamped to the minimum allowed value of 1',
-      context: { requested: rawFallback.duration },
+      context: { requested: fallbackOptions.duration },
     })
   }
 

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -11,7 +11,7 @@ import type {
   RedisClient,
   RequiredRateLimitConfig,
 } from './types.js'
-import { clamp, mergeConfig } from './utilities.js'
+import { clamp, mergeConfig, mergeFallback } from './utilities.js'
 
 const STEADY_NAMESPACE = 'rate-limit:'
 const BURST_NAMESPACE = 'rate-limit-burst:'
@@ -25,14 +25,6 @@ type RequiredFallbackConfig = Required<FallbackConfig>
  * than derived from the primary configuration — see ADR 0010.
  */
 const BASE_FALLBACK: RequiredFallbackConfig = { points: 10, duration: 1 }
-
-/**
- * Merge a partial fallback config over a fully-resolved base fallback.
- */
-const mergeFallback = (base: RequiredFallbackConfig, override?: FallbackConfig): RequiredFallbackConfig => ({
-  points: override?.points ?? base.points,
-  duration: override?.duration ?? base.duration,
-})
 
 /**
  * Clamp every numeric field, since caller input is not validated at the type

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -218,14 +218,14 @@ export const createRateLimiter = (options: CreateRateLimiterOptions): RateLimite
   // factory logger, since the fallback is resolved once per factory.
   if (fallback.points !== fallbackOptions.points) {
     logger?.warn({
-      message: 'fallback.points was clamped to the minimum allowed value of 1',
-      context: { requested: fallbackOptions.points },
+      message: 'Rate limit fallback points was clamped',
+      context: { value: fallbackOptions.points, clamped: fallback.points },
     })
   }
   if (fallback.duration !== fallbackOptions.duration) {
     logger?.warn({
-      message: 'fallback.duration was clamped to the minimum allowed value of 1',
-      context: { requested: fallbackOptions.duration },
+      message: 'Rate limit fallback duration was clamped',
+      context: { value: fallbackOptions.duration, clamped: fallback.duration },
     })
   }
 

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -142,10 +142,7 @@ const buildLimiter = (
   logger: Logger,
 ): RateLimiterAbstract | BurstyRateLimiter => {
   const { points, duration, burst, fallback } = config
-  // The fallback allowance (ADR 0010) stands in for the primary window
-  // whenever enforcement runs off memory, as insurance during a Redis outage
-  // or as the sole limiter with no `client` configured, so it must never
-  // reflect the (possibly much larger) primary points/duration.
+
   const memory = new RateLimiterMemory({
     points: fallback.points,
     duration: fallback.duration,
@@ -175,11 +172,7 @@ const buildLimiter = (
   if (!burst) {
     return steady
   }
-  // Burst grants nothing extra while degraded (ADR 0010): a dedicated,
-  // zero-capacity memory limiter rejects immediately and cleanly whenever
-  // Redis is unreachable, without touching the fallback allowance above. It
-  // sits inert whenever Redis is healthy, since insurance is only ever
-  // consulted on an infrastructure failure, never a legitimate rejection.
+
   return new BurstyRateLimiter(
     steady,
     new RateLimiterRedis({
@@ -188,6 +181,10 @@ const buildLimiter = (
       points: burst.points,
       duration: burst.duration,
       keyPrefix: `${BURST_NAMESPACE}${config.prefix}:`,
+      /**
+       * No burst during Redis outage, but we put a fallback to continue
+       * throwing `{@link RateLimitExceededError}` instead.
+       */
       insuranceLimiter: new RateLimiterMemory({
         points: 0,
         duration: burst.duration,

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -3,11 +3,36 @@ import { BurstyRateLimiter, RateLimiterMemory, RateLimiterRedis } from 'rate-lim
 
 import { BASE_RATE_LIMIT_DEFAULTS } from './constants.js'
 import { RateLimitExceededError } from './errors.js'
-import type { CreateRateLimiterOptions, Logger, RateLimitInfo, RedisClient, RequiredRateLimitConfig } from './types.js'
+import type {
+  CreateRateLimiterOptions,
+  FallbackConfig,
+  Logger,
+  RateLimitInfo,
+  RedisClient,
+  RequiredRateLimitConfig,
+} from './types.js'
 import { clamp, mergeConfig } from './utilities.js'
 
 const STEADY_NAMESPACE = 'rate-limit:'
 const BURST_NAMESPACE = 'rate-limit-burst:'
+
+type RequiredFallbackConfig = Required<FallbackConfig>
+
+/**
+ * The in-memory limiter's built-in fallback allowance: used as insurance
+ * behind a Redis-backed window during an outage, and as the sole limiter when
+ * no `client` is configured. A fixed, factory-independent constant rather
+ * than derived from the primary configuration — see ADR 0010.
+ */
+const BASE_FALLBACK: RequiredFallbackConfig = { points: 10, duration: 1 }
+
+/**
+ * Merge a partial fallback config over a fully-resolved base fallback.
+ */
+const mergeFallback = (base: RequiredFallbackConfig, override?: FallbackConfig): RequiredFallbackConfig => ({
+  points: override?.points ?? base.points,
+  duration: override?.duration ?? base.duration,
+})
 
 /**
  * Clamp every numeric field, since caller input is not validated at the type
@@ -116,25 +141,31 @@ export interface RateLimiter {
 
 const buildLimiter = (
   config: RequiredRateLimitConfig,
+  fallback: RequiredFallbackConfig,
   client: RedisClient | null,
   logger: Logger,
 ): RateLimiterAbstract | BurstyRateLimiter => {
   const { points, duration, burst } = config
-  const steadyMemoryLimiter = new RateLimiterMemory({ points, duration })
-  const burstMemoryLimiter = burst
-    ? new RateLimiterMemory({
-        points: burst.points,
-        duration: burst.duration,
-      })
-    : null
+  // The fallback allowance (ADR 0010) stands in for the primary window
+  // whenever enforcement runs off memory, as insurance during a Redis outage
+  // or as the sole limiter with no `client` configured, so it must never
+  // reflect the (possibly much larger) primary points/duration.
+  const fallbackMemory = new RateLimiterMemory({
+    points: fallback.points,
+    duration: fallback.duration,
+  })
 
   if (!client) {
     logger.warn({
       message:
-        'No Redis client configured, using in-memory rate limiting. Limits are per-instance and not shared across replicas.',
-      context: { prefix: config.prefix },
+        'No Redis client configured, using in-memory rate limiting at the fallback allowance. Limits are per-instance and not shared across replicas.',
+      context: {
+        prefix: config.prefix,
+        fallbackPoints: fallback.points,
+        fallbackDuration: fallback.duration,
+      },
     })
-    return burstMemoryLimiter ? new BurstyRateLimiter(steadyMemoryLimiter, burstMemoryLimiter) : steadyMemoryLimiter
+    return fallbackMemory
   }
 
   const steady = new RateLimiterRedis({
@@ -143,11 +174,16 @@ const buildLimiter = (
     points,
     duration,
     keyPrefix: `${STEADY_NAMESPACE}${config.prefix}:`,
-    insuranceLimiter: steadyMemoryLimiter,
+    insuranceLimiter: fallbackMemory,
   })
-  if (!burst || !burstMemoryLimiter) {
+  if (!burst) {
     return steady
   }
+  // Burst grants nothing extra while degraded (ADR 0010): a dedicated,
+  // zero-capacity memory limiter rejects immediately and cleanly whenever
+  // Redis is unreachable, without touching the fallback allowance above. It
+  // sits inert whenever Redis is healthy, since insurance is only ever
+  // consulted on an infrastructure failure, never a legitimate rejection.
   return new BurstyRateLimiter(
     steady,
     new RateLimiterRedis({
@@ -156,7 +192,10 @@ const buildLimiter = (
       points: burst.points,
       duration: burst.duration,
       keyPrefix: `${BURST_NAMESPACE}${config.prefix}:`,
-      insuranceLimiter: burstMemoryLimiter,
+      insuranceLimiter: new RateLimiterMemory({
+        points: 0,
+        duration: burst.duration,
+      }),
     }),
   )
 }
@@ -172,7 +211,32 @@ export const createRateLimiter = (options: CreateRateLimiterOptions): RateLimite
 
   const config = validateConfig(mergeConfig(BASE_RATE_LIMIT_DEFAULTS, options.overrides), logger)
 
-  const limiter = buildLimiter(config, client, logger)
+  // The fallback allowance is resolved once per factory. Keep it separate
+  // from the primary rate limit so an outage cannot grant the larger primary
+  // allowance.
+  const rawFallback = mergeFallback(BASE_FALLBACK, options.fallback)
+  const fallback: RequiredFallbackConfig = {
+    points: clamp(rawFallback.points),
+    duration: clamp(rawFallback.duration),
+  }
+  // A clamped fallback value is surfaced rather than silently corrected. The
+  // fallback governs the degraded path (ADR 0010), so a non-positive or
+  // non-finite value quietly becoming 1 would hide a misconfiguration in the
+  // path that matters most during an outage.
+  if (fallback.points !== rawFallback.points) {
+    logger?.warn({
+      message: 'fallback.points was clamped to the minimum allowed value of 1',
+      context: { requested: rawFallback.points },
+    })
+  }
+  if (fallback.duration !== rawFallback.duration) {
+    logger?.warn({
+      message: 'fallback.duration was clamped to the minimum allowed value of 1',
+      context: { requested: rawFallback.duration },
+    })
+  }
+
+  const limiter = buildLimiter(config, fallback, client, logger)
 
   return {
     check: async ({ key, logger: checkLogger }) => {

--- a/packages/rate-limit/src/rate-limiter.ts
+++ b/packages/rate-limit/src/rate-limiter.ts
@@ -148,7 +148,7 @@ const buildLimiter = (
   })
 
   if (!client) {
-    logger.warn({
+    logger.error({
       message:
         'No Redis client configured, using in-memory rate limiting at the fallback allowance. Limits are per-instance and not shared across replicas.',
       context: {

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -16,9 +16,10 @@ export interface BurstConfig {
 /**
  * Fallback allowance for the in-memory limiter used as insurance during a
  * Redis outage, and as the sole limiter when no `client` is configured. Both
- * fields are required when overriding the factory's built-in fallback. There
- * is no `burst` field: burst grants nothing extra while enforcement runs off
- * memory, regardless of the primary configuration — see ADR 0010.
+ * fields are required when overriding the factory's built-in fallback.
+ *
+ * There is no `burst` field: burst grants nothing extra while enforcement
+ * runs off memory, regardless of the primary configuration.
  *
  * @public
  */
@@ -52,11 +53,6 @@ export interface RateLimitConfig {
   /**
    * Fallback allowance for the in-memory limiter used as insurance during a
    * Redis outage, and as the sole limiter when no client is configured.
-   * Omit this property to use the factory's fallback default: 10 points per
-   * second, or 5 points per second for `createLocalRateLimiter`. When
-   * overriding it, both `points` and `duration` are required. This allowance
-   * is independent of the steady window, and burst grants nothing extra while
-   * enforcement runs off memory. See ADR 0010.
    */
   fallback?: FallbackConfig
   /**

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -14,6 +14,22 @@ export interface BurstConfig {
 }
 
 /**
+ * Fallback allowance for the in-memory limiter used as insurance during a
+ * Redis outage, and as the sole limiter when no `client` is configured. Both
+ * fields are required when overriding the factory's built-in fallback. There
+ * is no `burst` field: burst grants nothing extra while enforcement runs off
+ * memory, regardless of the primary configuration — see ADR 0010.
+ *
+ * @public
+ */
+export interface FallbackConfig {
+  /** Consumption points available per fallback window. */
+  points: number
+  /** Fallback window in seconds. */
+  duration: number
+}
+
+/**
  * Configuration for a rate-limit window. Omitted fields inherit the
  * limiter's defaults.
  *
@@ -34,6 +50,16 @@ export interface RateLimitConfig {
    */
   burst?: BurstConfig | null
   /**
+   * Fallback allowance for the in-memory limiter used as insurance during a
+   * Redis outage, and as the sole limiter when no client is configured.
+   * Omit this property to use the factory's fallback default: 10 points per
+   * second, or 5 points per second for `createLocalRateLimiter`. When
+   * overriding it, both `points` and `duration` are required. This allowance
+   * is independent of the steady window, and burst grants nothing extra while
+   * enforcement runs off memory. See ADR 0010.
+   */
+  fallback?: FallbackConfig
+  /**
    * Namespace segment isolating this limiter's counters from other limiters
    * sharing the same store. Steady counters are stored under
    * `rate-limit:<prefix>:` and burst counters under `rate-limit-burst:<prefix>:`.
@@ -41,7 +67,9 @@ export interface RateLimitConfig {
   prefix?: string
 }
 
-export type RequiredRateLimitConfig = Required<RateLimitConfig>
+export type RequiredRateLimitConfig = Required<RateLimitConfig> & {
+  fallback: Required<FallbackConfig>
+}
 
 /**
  * A snapshot of a key's rate-limit state after a check.
@@ -60,23 +88,6 @@ export interface RateLimitInfo {
   msToNextWindow: number
   /** Whether this check opened a new window. */
   isFirstInWindow: boolean
-}
-
-/**
- * Fallback allowance for the in-memory limiter used as insurance during a
- * Redis outage, and as the sole limiter when no `client` is configured. All
- * fields are optional; omitted fields inherit from the factory's built-in
- * fallback default. There is no `burst` field: burst grants nothing extra
- * while enforcement runs off memory, regardless of the primary configuration
- * — see ADR 0010.
- *
- * @public
- */
-export interface FallbackConfig {
-  /** Consumption points available per fallback window. Defaults to 10 (5 for `createLocalRateLimiter`). */
-  points?: number
-  /** Fallback window in seconds. Defaults to 1. */
-  duration?: number
 }
 
 /**
@@ -118,17 +129,6 @@ export interface CreateRateLimiterOptions {
    * Configuration merged over the limiter's built-in defaults.
    */
   overrides?: RateLimitConfig
-  /**
-   * Fallback allowance for the in-memory limiter used as insurance during a
-   * Redis outage, and as the sole limiter when no
-   * {@link CreateRateLimiterOptions.client | client} is configured. Defaults
-   * to 10 points per second (`createLocalRateLimiter` overrides this down to
-   * 5 points per second). This is independent of
-   * {@link CreateRateLimiterOptions.overrides | overrides}: a larger primary
-   * window does not raise the fallback, and burst is never part of it. See
-   * ADR 0010.
-   */
-  fallback?: FallbackConfig
   /**
    * Logger receiving configuration warnings and runtime
    * problems such as an unexpected store failure. Per-request logging

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -18,9 +18,6 @@ export interface BurstConfig {
  * Redis outage, and as the sole limiter when no `client` is configured. Both
  * fields are required when overriding the factory's built-in fallback.
  *
- * There is no `burst` field: burst grants nothing extra while enforcement
- * runs off memory, regardless of the primary configuration.
- *
  * @public
  */
 export interface FallbackConfig {
@@ -34,10 +31,6 @@ export interface FallbackConfig {
  * Configuration for a rate-limit window. Omitted fields inherit the
  * limiter's defaults.
  *
- * Numeric values are clamped to safe positive integers: non-finite or
- * below-1 values degrade to 1 and fractions are truncated, since the
- * Redis-backed limiter rejects non-integer arguments at runtime.
- *
  * @public
  */
 export interface RateLimitConfig {
@@ -48,6 +41,8 @@ export interface RateLimitConfig {
   /**
    * Burst window layered on top of the steady window. Omit to inherit the
    * limiter's default burst. Pass `null` to disable bursting entirely.
+   *
+   * Disabled during a Redis outage, and when no client is configured.
    */
   burst?: BurstConfig | null
   /**
@@ -57,7 +52,9 @@ export interface RateLimitConfig {
   fallback?: FallbackConfig
   /**
    * Namespace segment isolating this limiter's counters from other limiters
-   * sharing the same store. Steady counters are stored under
+   * sharing the same store.
+   *
+   * By default, steady counters are stored under
    * `rate-limit:<prefix>:` and burst counters under `rate-limit-burst:<prefix>:`.
    */
   prefix?: string
@@ -92,8 +89,6 @@ export interface RateLimitInfo {
  * Any logger whose `warn`/`error` accept `{ message, context?, error? }`
  * satisfies it, including the logger from `@opengovsg/logging`.
  *
- * The package takes no logging dependency.
- *
  * @public
  */
 export interface Logger {
@@ -103,7 +98,6 @@ export interface Logger {
 
 /**
  * The `ioredis` client used to share rate-limit counters across instances.
- * `ioredis` is an optional peer dependency.
  *
  * @public
  */
@@ -123,6 +117,10 @@ export interface CreateRateLimiterOptions {
   client?: RedisClient | null
   /**
    * Configuration merged over the limiter's built-in defaults.
+   *
+   * Numeric values are clamped to safe positive integers: non-finite or
+   * below-1 values degrade to 1 and fractions are truncated, since the
+   * Redis-backed limiter rejects non-integer arguments at runtime.
    */
   overrides?: RateLimitConfig
   /**

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -63,6 +63,23 @@ export interface RateLimitInfo {
 }
 
 /**
+ * Fallback allowance for the in-memory limiter used as insurance during a
+ * Redis outage, and as the sole limiter when no `client` is configured. All
+ * fields are optional; omitted fields inherit from the factory's built-in
+ * fallback default. There is no `burst` field: burst grants nothing extra
+ * while enforcement runs off memory, regardless of the primary configuration
+ * — see ADR 0010.
+ *
+ * @public
+ */
+export interface FallbackConfig {
+  /** Consumption points available per fallback window. Defaults to 10 (5 for `createLocalRateLimiter`). */
+  points?: number
+  /** Fallback window in seconds. Defaults to 1. */
+  duration?: number
+}
+
+/**
  * The subset of a structured logger this package needs.
  *
  * Any logger whose `warn`/`error` accept `{ message, context?, error? }`
@@ -101,6 +118,17 @@ export interface CreateRateLimiterOptions {
    * Configuration merged over the limiter's built-in defaults.
    */
   overrides?: RateLimitConfig
+  /**
+   * Fallback allowance for the in-memory limiter used as insurance during a
+   * Redis outage, and as the sole limiter when no
+   * {@link CreateRateLimiterOptions.client | client} is configured. Defaults
+   * to 10 points per second (`createLocalRateLimiter` overrides this down to
+   * 5 points per second). This is independent of
+   * {@link CreateRateLimiterOptions.overrides | overrides}: a larger primary
+   * window does not raise the fallback, and burst is never part of it. See
+   * ADR 0010.
+   */
+  fallback?: FallbackConfig
   /**
    * Logger receiving configuration warnings and runtime
    * problems such as an unexpected store failure. Per-request logging

--- a/packages/rate-limit/src/utilities.ts
+++ b/packages/rate-limit/src/utilities.ts
@@ -1,11 +1,7 @@
 import ipaddr from 'ipaddr.js'
 
 import { COLON_REPLACEMENT } from './constants.js'
-import {
-  FallbackConfig,
-  RateLimitConfig,
-  RequiredRateLimitConfig,
-} from './types.js'
+import { RateLimitConfig, RequiredRateLimitConfig } from './types.js'
 
 /**
  * Derive the store key for a client IP, or `null` when the input is not a
@@ -22,8 +18,7 @@ import {
  * @public
  */
 export const normalizeIp = (ip: string): string | null => {
-  if (!ipaddr.IPv4.isValidFourPartDecimal(ip) && !ipaddr.IPv6.isValid(ip))
-    return null
+  if (!ipaddr.IPv4.isValidFourPartDecimal(ip) && !ipaddr.IPv6.isValid(ip)) return null
 
   // `process` normalizes every spelling of an IPv4-mapped IPv6 address to
   // IPv4 so all representations of the client share one bucket.
@@ -52,26 +47,16 @@ export const clamp = (value: number): number => {
 }
 
 /**
- * Merge a partial config over a resolved base. Omitted `burst`
+ * Merge a partial config over a resolved base. Omitted `burst` and `fallback`
  * values inherit the base's. An explicit `null` disables bursting.
  */
-export const mergeConfig = (
-  base: RequiredRateLimitConfig,
-  override?: RateLimitConfig,
-): RequiredRateLimitConfig => ({
+export const mergeConfig = (base: RequiredRateLimitConfig, override?: RateLimitConfig): RequiredRateLimitConfig => ({
   points: override?.points ?? base.points,
   duration: override?.duration ?? base.duration,
   burst: override?.burst !== undefined ? override.burst : base.burst,
+  fallback: {
+    points: override?.fallback?.points ?? base.fallback.points,
+    duration: override?.fallback?.duration ?? base.fallback.duration,
+  },
   prefix: override?.prefix ?? base.prefix,
-})
-
-/**
- * Merge a partial fallback config over a fully-resolved base fallback.
- */
-export const mergeFallback = (
-  base: Required<FallbackConfig>,
-  override?: FallbackConfig,
-): Required<FallbackConfig> => ({
-  points: override?.points ?? base.points,
-  duration: override?.duration ?? base.duration,
 })

--- a/packages/rate-limit/src/utilities.ts
+++ b/packages/rate-limit/src/utilities.ts
@@ -47,7 +47,7 @@ export const clamp = (value: number): number => {
 }
 
 /**
- * Merge a partial config over a resolved base. Omitted `burst` and `fallback`
+ * Merge a partial config over a base config. Omitted `burst` and `fallback`
  * values inherit the base's. An explicit `null` disables bursting.
  */
 export const mergeConfig = (base: RequiredRateLimitConfig, override?: RateLimitConfig): RequiredRateLimitConfig => ({

--- a/packages/rate-limit/src/utilities.ts
+++ b/packages/rate-limit/src/utilities.ts
@@ -1,7 +1,11 @@
 import ipaddr from 'ipaddr.js'
 
 import { COLON_REPLACEMENT } from './constants.js'
-import { RateLimitConfig, RequiredRateLimitConfig } from './types.js'
+import {
+  FallbackConfig,
+  RateLimitConfig,
+  RequiredRateLimitConfig,
+} from './types.js'
 
 /**
  * Derive the store key for a client IP, or `null` when the input is not a
@@ -18,7 +22,8 @@ import { RateLimitConfig, RequiredRateLimitConfig } from './types.js'
  * @public
  */
 export const normalizeIp = (ip: string): string | null => {
-  if (!ipaddr.IPv4.isValidFourPartDecimal(ip) && !ipaddr.IPv6.isValid(ip)) return null
+  if (!ipaddr.IPv4.isValidFourPartDecimal(ip) && !ipaddr.IPv6.isValid(ip))
+    return null
 
   // `process` normalizes every spelling of an IPv4-mapped IPv6 address to
   // IPv4 so all representations of the client share one bucket.
@@ -50,9 +55,23 @@ export const clamp = (value: number): number => {
  * Merge a partial config over a resolved base. Omitted `burst`
  * values inherit the base's. An explicit `null` disables bursting.
  */
-export const mergeConfig = (base: RequiredRateLimitConfig, override?: RateLimitConfig): RequiredRateLimitConfig => ({
+export const mergeConfig = (
+  base: RequiredRateLimitConfig,
+  override?: RateLimitConfig,
+): RequiredRateLimitConfig => ({
   points: override?.points ?? base.points,
   duration: override?.duration ?? base.duration,
   burst: override?.burst !== undefined ? override.burst : base.burst,
   prefix: override?.prefix ?? base.prefix,
+})
+
+/**
+ * Merge a partial fallback config over a fully-resolved base fallback.
+ */
+export const mergeFallback = (
+  base: Required<FallbackConfig>,
+  override?: FallbackConfig,
+): Required<FallbackConfig> => ({
+  points: override?.points ?? base.points,
+  duration: override?.duration ?? base.duration,
 })

--- a/packages/validators/.prettierignore
+++ b/packages/validators/.prettierignore
@@ -1,1 +1,5 @@
+dist
+node_modules
+.cache
+.turbo
 tsconfig.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@opengovsg/prettier-config-starter-kitty':
         specifier: workspace:*
         version: link:../prettier-config
+      '@opengovsg/testcontainers':
+        specifier: workspace:*
+        version: link:../testcontainers
       '@swc/core':
         specifier: ^1.6.13
         version: 1.6.13
@@ -173,12 +176,18 @@ importers:
       ioredis:
         specifier: ^5.8.2
         version: 5.11.1
+      testcontainers:
+        specifier: ^12.0.4
+        version: 12.0.4
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@20.19.24)(vite@7.3.6(@types/node@20.19.24)(yaml@2.4.5))
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 4.3.6
 
   packages/testcontainers:
     devDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
       "dependsOn": ["^build:report", "^build:docs"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^build", "^lint"]
     },
     "lint:fix": {
       "dependsOn": ["^lint:fix"]
@@ -23,7 +23,7 @@
       "dependsOn": ["^format:check"]
     },
     "test": {
-      "dependsOn": ["^test"]
+      "dependsOn": ["^build"]
     },
     "ci:report": {
       "dependsOn": ["build"]


### PR DESCRIPTION
docs(adr): add ADR 0010, clamp insurance limiter fallback allowance

Documents the decision to scale the in-memory fallback limiter to 1/10th
of the primary window, disable burst while running in fallback, and add
a fallback config option, so a Redis outage tightens enforcement instead
of multiplying it by replica count.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

feat(rate-limit): add public FallbackConfig type

feat(rate-limit): clamp the in-memory fallback allowance (ADR 0010)

feat(rate-limit): tighten createLocalRateLimiter's fallback to 5/s

test(rate-limit): add real-Redis coverage via testcontainers

docs(rate-limit): regenerate API report and add changeset for ADR 0010