### PR TITLE
feat(ci): dual publish packages to npm and GitHub Packages

### DIFF
--- a/.github/scripts/publish-github-packages.sh
+++ b/.github/scripts/publish-github-packages.sh
@@ -22,6 +22,16 @@ for manifest in packages/*/package.json; do
   [ -z "$name" ] && continue
   version=$(jq -r '.version' "$manifest")
 
+  # In snapshot mode (tag given), a run with no pending changesets leaves
+  # package.json at its last real, already-released version instead of a
+  # fresh `-<tag>-<timestamp>` bump. npm correctly no-ops on that; mirror
+  # the no-op here instead of republishing the release version under the
+  # snapshot tag.
+  if [ -n "${1:-}" ] && npm view "$name@$version" --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+    echo "$name@$version is already released on npm (no new snapshot), skipping"
+    continue
+  fi
+
   if view_output=$(npm view "$name@$version" --registry=https://npm.pkg.github.com 2>&1); then
     echo "$name@$version already published to GitHub Packages, skipping"
   elif echo "$view_output" | grep -q 'E404'; then

--- a/.github/scripts/publish-github-packages.sh
+++ b/.github/scripts/publish-github-packages.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Mirrors an already-done (or in-progress) npm publish over to GitHub
+# Packages, for every publishable workspace package at its current on-disk
+# version. Run this AFTER the npm publish step, with the registry already
+# pointed at https://npm.pkg.github.com (e.g. via actions/setup-node's
+# registry-url) and NODE_AUTH_TOKEN set to a token with `packages: write`.
+#
+# Usage: publish-github-packages.sh [dist-tag]
+set -euo pipefail
+
+tag_flag=()
+if [ -n "${1:-}" ]; then
+  tag_flag=(--tag "$1")
+fi
+
+for manifest in packages/*/package.json; do
+  if [ "$(jq -r '.private // false' "$manifest")" = "true" ]; then
+    continue
+  fi
+
+  name=$(jq -r '.name // empty' "$manifest")
+  [ -z "$name" ] && continue
+  version=$(jq -r '.version' "$manifest")
+
+  if view_output=$(npm view "$name@$version" --registry=https://npm.pkg.github.com 2>&1); then
+    echo "$name@$version already published to GitHub Packages, skipping"
+  elif echo "$view_output" | grep -q 'E404'; then
+    echo "Publishing $name@$version to GitHub Packages"
+    pnpm --filter "$name" publish --no-git-checks "${tag_flag[@]}"
+  else
+    echo "$view_output" >&2
+    exit 1
+  fi
+done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,6 +73,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
 
+      - name: Configure registry for GitHub Packages
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Publish snapshot to GitHub Packages
+        run: .github/scripts/publish-github-packages.sh snapshot
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release:
     name: Release
     runs-on: ubuntu-latest
@@ -80,6 +92,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      packages: write
     steps:
       # Mint a token from the reusable Changesets GitHub App so the Version
       # Packages PR is created with a non-default identity. PRs/pushes made
@@ -127,3 +140,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+
+      - name: Configure registry for GitHub Packages
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Publish to GitHub Packages
+        if: steps.changesets.outputs.published == 'true'
+        run: .github/scripts/publish-github-packages.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Publish all publishable workspace packages (`@opengovsg/logging`, `@opengovsg/testcontainers`, `@opengovsg/validators`) to GitHub Packages (`npm.pkg.github.com`) in addition to npm, in both the `snapshot` and `release` jobs.
- Adds `packages: write` permission to both jobs; reuses `secrets.GITHUB_TOKEN` (no new secret needed).
- The release job's GitHub Packages step is gated on `steps.changesets.outputs.published == 'true'`, so it only runs on an actual publish, not when changesets-action is just opening/updating the "Version Packages" PR (at that point the working tree already has bumped-but-unpublished versions on disk).
- New shared script `.github/scripts/publish-github-packages.sh` checks each publishable package against GitHub Packages via `npm view` and publishes any version not yet present, treating non-404 registry errors as fatal. Pattern based on `opengovsg/confetti#615`, generalized to loop over this repo's multiple publishable packages.

## Test plan
- [ ] Trigger `workflow_dispatch` with `snapshot: true` and confirm packages land in both npm (tag `snapshot`) and this repo's GitHub Packages tab.
- [ ] Confirm a real release (merging the Version Packages PR) still publishes to npm and additionally shows up under the repo's Packages tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)